### PR TITLE
[Feature] 총 사용자 수를 보여주는 그래프를 admin 페이지에 구현

### DIFF
--- a/src/main/java/com/example/e2ekernelengine/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/admin/controller/AdminController.java
@@ -1,0 +1,28 @@
+package com.example.e2ekernelengine.domain.admin.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.e2ekernelengine.domain.admin.dto.response.UserCountResponse;
+import com.example.e2ekernelengine.domain.admin.service.AdminService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin")
+public class AdminController {
+
+	private final AdminService adminService;
+
+	@GetMapping("user-count/jpa")
+	public UserCountResponse getTotalUserCountByJpa() {
+		return adminService.getTotalUserCountByJpa();
+	}
+
+	@GetMapping("user-count/query")
+	public UserCountResponse getTotalUserCountByNativeQuery() {
+		return adminService.getTotalUserCountByNativeQuery();
+	}
+}

--- a/src/main/java/com/example/e2ekernelengine/domain/admin/dto/DateAndTotalUserCountDto.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/admin/dto/DateAndTotalUserCountDto.java
@@ -1,0 +1,19 @@
+package com.example.e2ekernelengine.domain.admin.dto;
+
+import java.math.BigInteger;
+import java.time.LocalDate;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class DateAndTotalUserCountDto {
+	private final LocalDate date;
+	private final BigInteger totalUserCount;
+
+	@Builder
+	public DateAndTotalUserCountDto(LocalDate date, BigInteger totalUserCount) {
+		this.date = date;
+		this.totalUserCount = totalUserCount;
+	}
+}

--- a/src/main/java/com/example/e2ekernelengine/domain/admin/dto/response/UserCountResponse.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/admin/dto/response/UserCountResponse.java
@@ -1,0 +1,21 @@
+package com.example.e2ekernelengine.domain.admin.dto.response;
+
+import java.util.List;
+
+import com.example.e2ekernelengine.domain.admin.dto.DateAndTotalUserCountDto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class UserCountResponse {
+	private final List<DateAndTotalUserCountDto> thisWeekTotalUserCountList;
+	private final List<DateAndTotalUserCountDto> lastWeekTotalUserCountList;
+
+	@Builder
+	public UserCountResponse(List<DateAndTotalUserCountDto> thisWeekTotalUserCountList,
+			List<DateAndTotalUserCountDto> lastWeekTotalUserCountList) {
+		this.thisWeekTotalUserCountList = thisWeekTotalUserCountList;
+		this.lastWeekTotalUserCountList = lastWeekTotalUserCountList;
+	}
+}

--- a/src/main/java/com/example/e2ekernelengine/domain/admin/service/AdminService.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/admin/service/AdminService.java
@@ -1,0 +1,96 @@
+package com.example.e2ekernelengine.domain.admin.service;
+
+import java.math.BigInteger;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.example.e2ekernelengine.domain.admin.dto.DateAndTotalUserCountDto;
+import com.example.e2ekernelengine.domain.admin.dto.response.UserCountResponse;
+import com.example.e2ekernelengine.domain.user.db.entity.User;
+import com.example.e2ekernelengine.domain.user.db.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class AdminService {
+
+	private final UserRepository userRepository;
+
+	public UserCountResponse getTotalUserCountByJpa() {
+		// TODO: 지난주부터 이번주까지 USer 기록을 꺼내온다.
+		LocalDateTime startDatetime = LocalDateTime.of(LocalDate.now().minusDays(14), LocalTime.of(0, 0, 0));
+		LocalDateTime endDatetime = LocalDateTime.of(LocalDate.now(), LocalTime.of(23, 59, 59));
+		log.debug("startDatetime: {}", startDatetime);
+		log.debug("endDatetime: {}", endDatetime);
+		
+		List<User> userList = userRepository.findAllByUserRegisteredAtBetweenOrderByUserRegisteredAt(
+				Timestamp.valueOf(startDatetime), Timestamp.valueOf(endDatetime));
+
+		// TODO: 날짜별로 count
+		// Map<Timestamp, Long> countByDate = userList.stream()
+		// 		.collect(Collectors.groupingBy(User::getUserRegisteredAt, Collectors.counting()));
+		//
+		// List<Map.Entry<Timestamp, Long>> countList = countByDate.entrySet().stream()
+		// 		.sorted(Map.Entry.comparingByKey())
+		// 		.collect(Collectors.toList());
+		//
+		// // countList를 사용하거나, 필요에 따라 User 객체 리스트로 변환할 수 있어.
+		// List<User> countedUserList = countList.stream()
+		// 		.map(entry -> {
+		// 			User user = new User();
+		// 			user.setUserRegisteredAt(entry.getKey());
+		// 			user.setCount(entry.getValue()); // User 클래스에 count 필드를 추가해야 함
+		// 			// 다른 필요한 필드들도 여기에 추가
+		// 			return user;
+		// 		})
+		// 		.collect(Collectors.toList());
+
+		// TODO: total count 정리해서 response로 내보낸다.
+
+		return null;
+	}
+
+	public UserCountResponse getTotalUserCountByNativeQuery() {
+		List<Object[]> result = userRepository.getCountAndDateInRangeOrdered();
+		LocalDate beforeOneWeek = LocalDate.now().minusDays(7);
+
+		result.forEach(row -> {
+			log.debug("row: {}", Arrays.toString(row));
+		});
+
+		List<DateAndTotalUserCountDto> thisWeeKUserCountList = new ArrayList<>();
+		List<DateAndTotalUserCountDto> lastWeekUserCountList = new ArrayList<>();
+
+		for (int i = 0; i < result.size(); i++) {
+			DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yy-MM-dd");
+			LocalDate date = LocalDate.parse((CharSequence)result.get(i)[1], formatter);
+			if (date.isAfter(beforeOneWeek)) {
+				thisWeeKUserCountList.add(DateAndTotalUserCountDto.builder()
+						.date(date)
+						.totalUserCount((BigInteger)result.get(i)[0])
+						.build());
+			} else {
+				lastWeekUserCountList.add(DateAndTotalUserCountDto.builder()
+						.date(date)
+						.totalUserCount((BigInteger)result.get(i)[0])
+						.build());
+			}
+		}
+
+		return UserCountResponse.builder()
+				.thisWeekTotalUserCountList(thisWeeKUserCountList)
+				.lastWeekTotalUserCountList(lastWeekUserCountList)
+				.build();
+	}
+}

--- a/src/main/java/com/example/e2ekernelengine/domain/user/db/repository/UserRepository.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/user/db/repository/UserRepository.java
@@ -1,5 +1,7 @@
 package com.example.e2ekernelengine.domain.user.db.repository;
 
+import java.sql.Timestamp;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,4 +19,20 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	@Query("SELECT u FROM User u WHERE u.userStatusType = 'ACTIVE' AND u.userEmail = :userEmail")
 	Optional<User> findActiveUserByUserEmail(@Param("userEmail") String userEmail);
 
+	List<User> findAllByUserRegisteredAtBetween(Timestamp startDatetime, Timestamp endDatetime);
+
+	@Query(value = "SELECT COUNT(*) AS count, DATE_FORMAT(user_registered_at, '%y-%m-%d') AS date " +
+			"FROM user " +
+			"WHERE DATE_FORMAT(user_registered_at, '%y-%m-%d') BETWEEN DATE_FORMAT(CURDATE() - INTERVAL 14 DAY, '%y-%m-%d') AND DATE_FORMAT(CURDATE(), '%y-%m-%d') "
+			+ "GROUP BY date", nativeQuery = true)
+	List<Object[]> getCountByDateInRange();
+
+	@Query(value = "SELECT COUNT(*) AS count, DATE_FORMAT(user_registered_at, '%y-%m-%d') AS date " +
+			"FROM user " +
+			"WHERE DATE_FORMAT(user_registered_at, '%y-%m-%d') BETWEEN DATE_FORMAT(CURDATE() - INTERVAL 14 DAY, '%y-%m-%d') AND DATE_FORMAT(CURDATE(), '%y-%m-%d') "
+			+ "GROUP BY date " +
+			"ORDER BY date", nativeQuery = true)
+	List<Object[]> getCountAndDateInRangeOrdered();
+
+	List<User> findAllByUserRegisteredAtBetweenOrderByUserRegisteredAt(Timestamp start, Timestamp end);
 }

--- a/src/main/java/com/example/e2ekernelengine/domain/user/db/repository/UserRepository.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/user/db/repository/UserRepository.java
@@ -24,12 +24,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	@Query(value = "SELECT COUNT(*) AS count, DATE_FORMAT(user_registered_at, '%y-%m-%d') AS date " +
 			"FROM user " +
 			"WHERE DATE_FORMAT(user_registered_at, '%y-%m-%d') BETWEEN DATE_FORMAT(CURDATE() - INTERVAL 14 DAY, '%y-%m-%d') AND DATE_FORMAT(CURDATE(), '%y-%m-%d') "
-			+ "GROUP BY date", nativeQuery = true)
-	List<Object[]> getCountByDateInRange();
-
-	@Query(value = "SELECT COUNT(*) AS count, DATE_FORMAT(user_registered_at, '%y-%m-%d') AS date " +
-			"FROM user " +
-			"WHERE DATE_FORMAT(user_registered_at, '%y-%m-%d') BETWEEN DATE_FORMAT(CURDATE() - INTERVAL 14 DAY, '%y-%m-%d') AND DATE_FORMAT(CURDATE(), '%y-%m-%d') "
 			+ "GROUP BY date " +
 			"ORDER BY date", nativeQuery = true)
 	List<Object[]> getCountAndDateInRangeOrdered();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,12 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: ${MYSQL_DATABASE_USERNAME}
     password: ${MYSQL_DATABASE_PASSWORD}
+
+  #  servlet:
+  #    multipart:
+  #      max-file-size: 10MB
+  #      max-request-size: 10MB
+
   thymeleaf:
     prefix: classpath:templates/
     check-template-location: true

--- a/src/main/resources/templates/manage/adminPage.html
+++ b/src/main/resources/templates/manage/adminPage.html
@@ -693,23 +693,40 @@ to get the desired effect
     google.charts.setOnLoadCallback(drawChart);
 
     function drawChart() {
-        var data = google.visualization.arrayToDataTable([
-            ['Year', '지난주', '이번주'],
-            ['2004', 1000, 400],
-            ['2005', 1170, 460],
-            ['2006', 660, 1120],
-            ['2007', 1030, 540]
-        ]);
+        $.ajax({
+            url: `http://localhost:8080/api/v1/admin/user-count/query`,
+            method: 'GET',
+            dataType: 'json',
+            success: function (data) {
 
-        var options = {
-            title: '총 사용자 추이',
-            curveType: 'function',
-            legend: {position: 'bottom'}
-        };
+                const thisWeek = data.thisWeekTotalUserCountList;
+                const lastWeek = data.lastWeekTotalUserCountList;
+                console.log(thisWeek);
 
-        var chart = new google.visualization.LineChart(document.getElementById('curve_chart'));
+                var tableData = google.visualization.arrayToDataTable([
+                    ['Date', '지난주', '이번주'],
+                    [thisWeek[0].date, lastWeek[0].totalUserCount, thisWeek[0].totalUserCount],
+                    [thisWeek[1].date, lastWeek[1].totalUserCount, thisWeek[1].totalUserCount],
+                    [thisWeek[2].date, lastWeek[2].totalUserCount, thisWeek[2].totalUserCount],
+                    [thisWeek[3].date, lastWeek[3].totalUserCount, thisWeek[3].totalUserCount],
+                    [thisWeek[4].date, lastWeek[4].totalUserCount, thisWeek[4].totalUserCount],
+                    [thisWeek[5].date, lastWeek[5].totalUserCount, thisWeek[5].totalUserCount]
+                ]);
 
-        chart.draw(data, options);
+                var options = {
+                    title: '총 사용자 추이',
+                    curveType: 'function',
+                    legend: { position: 'bottom' }
+                };
+
+                var chart = new google.visualization.LineChart(document.getElementById('curve_chart'));
+
+                chart.draw(tableData, options);
+            },
+            error: function (error) {
+                console.error('데이터를 가져오는데 실패했습니다.', error);
+            }
+        });
     }
 </script>
 

--- a/src/main/resources/templates/manage/adminPage.html
+++ b/src/main/resources/templates/manage/adminPage.html
@@ -16,6 +16,19 @@
     <!-- Google Font: Source Sans Pro -->
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700" rel="stylesheet">
 </head>
+
+<style>
+    .card-body {
+        display: flex;
+        flex-direction: column; /* 세로로 쌓이도록 설정 */
+        align-items: center; /* 가운데 정렬 */
+    }
+
+    #curve_chart {
+        width: 100%; /* 부모 요소(card-body)에 맞게 100%로 설정 */
+        height: 100%; /* 부모 요소(card-body)에 맞게 100%로 설정 */
+    }
+</style>
 <!--
 BODY TAG OPTIONS:
 =================
@@ -186,7 +199,7 @@ to get the desired effect
                         <div class="card">
                             <div class="card-header border-0">
                                 <div class="d-flex justify-content-between">
-                                    <h3 class="card-title">방문자 추이</h3>
+                                    <h3 class="card-title">가입자 추이</h3>
                                     <a href="javascript:void(0);">View Report</a>
                                 </div>
                             </div>
@@ -194,30 +207,32 @@ to get the desired effect
                                 <div class="d-flex">
                                     <p class="d-flex flex-column">
                                         <span class="text-bold text-lg">820</span>
-                                        <span>Visitors Over Time</span>
+                                        <span>총 가입자 추이</span>
                                     </p>
-                                    <p class="ml-auto d-flex flex-column text-right">
-                    <span class="text-success">
-                      <i class="fas fa-arrow-up"></i> 12.5%
-                    </span>
-                                        <span class="text-muted">Since last week</span>
-                                    </p>
+                                    <!--                                    TODO: 퍼센트 구현하기 -->
+                                    <!--                                    <p class="ml-auto d-flex flex-column text-right">-->
+                                    <!--                    <span class="text-success">-->
+                                    <!--                      <i class="fas fa-arrow-up"></i> 12.5% -->
+                                    <!--                    </span>-->
+                                    <!--                                        <span class="text-muted">Since last week</span>-->
+                                    <!--                                    </p>-->
                                 </div>
                                 <!-- /.d-flex -->
-
-                                <div class="position-relative mb-4">
-                                    <canvas height="200" id="visitors-chart"></canvas>
+                                    <div id="curve_chart"></div>
                                 </div>
+                                <!--                                <div class="position-relative mb-4">-->
+                                <!--                                    <canvas height="200" id="visitors-chart"></canvas>-->
+                                <!--                                </div>-->
 
-                                <div class="d-flex flex-row justify-content-end">
-                  <span class="mr-2">
-                    <i class="fas fa-square text-primary"></i> This Week
-                  </span>
+                                <!--                                <div class="d-flex flex-row justify-content-end">-->
+                                <!--                  <span class="mr-2">-->
+                                <!--                    <i class="fas fa-square text-primary"></i> This Week-->
+                                <!--                  </span>-->
 
-                                    <span>
-                    <i class="fas fa-square text-gray"></i> Last Week
-                  </span>
-                                </div>
+                                <!--                                    <span>-->
+                                <!--                    <i class="fas fa-square text-gray"></i> Last Week-->
+                                <!--                  </span>-->
+                                <!--                                </div>-->
                             </div>
                         </div>
                         <!-- /.card -->
@@ -672,6 +687,32 @@ to get the desired effect
 <!-- AdminLTE -->
 <script src="/dist/js/adminlte.js"></script>
 
+<script src="https://www.gstatic.com/charts/loader.js" type="text/javascript"></script>
+<script type="text/javascript">
+    google.charts.load('current', {'packages': ['corechart']});
+    google.charts.setOnLoadCallback(drawChart);
+
+    function drawChart() {
+        var data = google.visualization.arrayToDataTable([
+            ['Year', '지난주', '이번주'],
+            ['2004', 1000, 400],
+            ['2005', 1170, 460],
+            ['2006', 660, 1120],
+            ['2007', 1030, 540]
+        ]);
+
+        var options = {
+            title: '총 사용자 추이',
+            curveType: 'function',
+            legend: {position: 'bottom'}
+        };
+
+        var chart = new google.visualization.LineChart(document.getElementById('curve_chart'));
+
+        chart.draw(data, options);
+    }
+</script>
+
 <script>
 
     function initializeTable() {
@@ -736,12 +777,6 @@ to get the desired effect
             $.ajax({
                 url: 'http://localhost:8080/api/v1/blogs',
                 method: 'POST',
-                // data: {
-                //     description: $('#blogTitle').val(),
-                //     blogWriterName: $('#blogWriterName').val(),
-                //     rss: $('#blogRSS').val(),
-                //     blogOwnerType: $('select[name="blogType"]').val()
-                // },
                 data: JSON.stringify({
                     description: $('#blogTitle').val(),
                     blogWriterName: $('#blogWriterName').val(),
@@ -749,7 +784,7 @@ to get the desired effect
                     blogOwnerType: $('select[name="blogType"]').val()
                 }),
                 contentType: 'application/json',
-                
+
                 success: function (response) {
                     console.log('API 요청 성공', response);
                 },

--- a/src/test/java/com/example/e2ekernelengine/domain/user/db/repository/UserRepositoryTest.java
+++ b/src/test/java/com/example/e2ekernelengine/domain/user/db/repository/UserRepositoryTest.java
@@ -1,0 +1,74 @@
+package com.example.e2ekernelengine.domain.user.db.repository;
+
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+// @SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class UserRepositoryTest {
+
+	// @Autowired
+	// UserRepository userRepository;
+	//
+	// @Test
+	// @DisplayName("지난주부터 이번주까지 User 기록을 꺼내온다.")
+	// void findAllByUserRegisteredAtBetweenTest() {
+	// 	//given
+	// 	List<User> users = generateUsersForTest();
+	// 	userRepository.saveAll(users);
+	//
+	// 	LocalDateTime lastWeek = LocalDateTime.now().minusWeeks(2);
+	// 	LocalDateTime lastWeekTimestamp = lastWeek;
+	// 	LocalDateTime thisWeekTimestamp = LocalDateTime.now();
+	//
+	// 	// When
+	// 	List<User> result = userRepository.findAllByUserRegisteredAtBetween(Timestamp.valueOf(lastWeekTimestamp),
+	// 			Timestamp.valueOf(thisWeekTimestamp));
+	//
+	// 	// Then
+	// 	assertThat(result).isNotNull();
+	// 	assertThat(result).hasSize(15);
+	// }
+	//
+	// private Timestamp generateRandomDate(String startDate, String endDate) {
+	// 	LocalDate start = LocalDate.parse(startDate);
+	// 	LocalDate end = LocalDate.parse(endDate);
+	//
+	// 	long startEpochDay = start.toEpochDay();
+	// 	long endEpochDay = end.toEpochDay();
+	//
+	// 	long randomDay = startEpochDay + (long)(Math.random() * (endEpochDay - startEpochDay + 1));
+	// 	Instant instant = LocalDate.ofEpochDay(randomDay).atStartOfDay(ZoneId.systemDefault()).toInstant();
+	//
+	// 	return Timestamp.from(instant);
+	// }
+	//
+	// private List<User> generateUsersForTest() {
+	// 	List<User> users = new ArrayList<>();
+	//
+	// 	for (int i = 0; i < 15; i++) {
+	// 		User user = User.builder()
+	// 				.userEmail("user" + i + "@example.com")
+	// 				.userName("user" + i)
+	// 				.userPassword("password" + i)
+	// 				.userRegisteredAt(generateRandomDate("2023-10-26", "2023-11-09"))
+	// 				.build();
+	//
+	// 		users.add(user);
+	// 	}
+	//
+	// 	for (int i = 15; i < 20; i++) {
+	// 		User user = User.builder()
+	// 				.userEmail("user" + i + "@example.com")
+	// 				.userName("user" + i)
+	// 				.userPassword("password" + i)
+	// 				.userRegisteredAt(generateRandomDate("2023-01-01", "2023-10-25"))
+	// 				.build();
+	//
+	// 		users.add(user);
+	// 	}
+	//
+	// 	return users;
+	// }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,64 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQL5InnoDBDialect
+  #  jpa:
+  #    show-sql: true
+  #    properties:
+  #      format_sql: true
+  #      database: mysql
+  #      dialect: org.hibernate.dialect.MySQL8Dialect
+  #    hibernate:
+  #      ddl-auto: validate
+  datasource:
+    url: ${MYSQL_DATABASE_URL}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: ${MYSQL_DATABASE_USERNAME}
+    password: ${MYSQL_DATABASE_PASSWORD}
+
+  #  servlet:
+  #    multipart:
+  #      max-file-size: 10MB
+  #      max-request-size: 10MB
+
+  thymeleaf:
+    prefix: classpath:templates/
+    check-template-location: true
+    suffix: .html
+    mode: HTML
+    cache: false
+
+  thymeleaf3:
+    decoupled-logic: true
+
+logging:
+  level:
+    com.example: debug
+    org.springframework.security: debug
+#    org:
+#      springframework:
+#        data:
+#          elasticsearch:
+#            client:
+#              WIRE: TRACE
+##                WIRE=TRACE
+
+server:
+  port: 8080
+
+
+token:
+  secret:
+    key: ${JWT_SECRET_KEY}
+  access-token:
+    plus-minute: 30
+  refresh-token:
+    plus-hour: 24
+  cookie:
+    name: ${COOKIE_NAME}
+    refresh-name: ${COOKIE_REFRESH_NAME}


### PR DESCRIPTION
## 💡 Motivation
- 총 사용자 수 추이를 보여주는 그래프를 구현했습니다. 

## 🔨 Modified
- 날짜별로 가입한 사용자의 수를 조회하는 방법에 대해서 
  1. `DB`에서 `count`값을 `반환`하도록 쿼리 작성하기 
  2. 원하는 기간에 가입한 `user의 정보를 모두 조회`하여 `서버에서` 날짜별 가입한 사용자 수를 `계산`하기 
  로 두가지가 있었고 어떤 쿼리문이 DB에 더 부하를 줄지 궁금해져서 시간이 되면 두가지 버전을 모두 구현하려고 했습니다. 하지만 시간상의 이유로 `1번 방법으로만 구현`하였고, 2번은 `백로그`로 남겨두겠습니다. 
- test를 작성하고자 하였으나 지식 부족의 이유로 실패했고 일정상의 이유로 또....`백로그`로 남겨두겠습니다. ...

## 🤟🏻 Results
- admin page에 가입자 수 추이를 보여주는 차트 구현 완료
![image](https://github.com/Kernel360/E2E1-KernelEngine/assets/68376744/eaf44eeb-08b4-426a-b63b-44d340ad5b66)

## TODO 

## Issue
- close #68 

---

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
