### PR TITLE
[Feature] 메인페이지에 조회순, 최신순 필터 적용

### DIFF
--- a/src/main/java/com/example/e2ekernelengine/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/feed/controller/FeedController.java
@@ -47,6 +47,14 @@ public class FeedController {
 		return ResponseEntity.ok(feedList);
 	}
 
+	@GetMapping("/most-clicked")
+	public ResponseEntity<Page<FeedPageableResponse>> findMostClickedFeedList(
+			@PageableDefault(size = 5, sort = "visitCount", direction = Sort.Direction.DESC) Pageable pageable) {
+
+		Page<FeedPageableResponse> feedList = feedService.findMostClickedFeedList(pageable);
+		return ResponseEntity.ok(feedList);
+	}
+
 	@PostMapping("/visit/{feedId}")
 	public void updateDailyVisitCount(@PathVariable Long feedId) {
 		feedService.increaseDailyVisitCount(feedId);

--- a/src/main/java/com/example/e2ekernelengine/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/feed/controller/FeedController.java
@@ -47,7 +47,7 @@ public class FeedController {
 		return ResponseEntity.ok(feedList);
 	}
 
-	@GetMapping("/most-clicked")
+	@GetMapping("/clicked")
 	public ResponseEntity<Page<FeedPageableResponse>> findMostClickedFeedList(
 			@PageableDefault(size = 5, sort = "visitCount", direction = Sort.Direction.DESC) Pageable pageable) {
 

--- a/src/main/java/com/example/e2ekernelengine/domain/feed/db/repository/FeedRepository.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/feed/db/repository/FeedRepository.java
@@ -18,7 +18,5 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
 	List<Feed> searchFeedsByKeyword(@Param("keyword") String keyword);
 
 	Page<Feed> findAll(Pageable request);
-	
-	Page<Feed> findAllByOrderByVisitCountDesc(Pageable request);
 
 }

--- a/src/main/java/com/example/e2ekernelengine/domain/feed/db/repository/FeedRepository.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/feed/db/repository/FeedRepository.java
@@ -18,5 +18,7 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
 	List<Feed> searchFeedsByKeyword(@Param("keyword") String keyword);
 
 	Page<Feed> findAll(Pageable request);
+	
+	Page<Feed> findAllByOrderByVisitCountDesc(Pageable request);
 
 }

--- a/src/main/java/com/example/e2ekernelengine/domain/feed/service/FeedService.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/feed/service/FeedService.java
@@ -73,6 +73,11 @@ public class FeedService {
 		return feedRepository.findAll(pageable).map(FeedPageableResponse::fromEntity);
 	}
 
+	public Page<FeedPageableResponse> findMostClickedFeedList(Pageable pageable) {
+		return feedRepository.findAllByOrderByVisitCountDesc(pageable)
+				.map(FeedPageableResponse::fromEntity);
+	}
+
 	public void increaseDailyVisitCount(Long feedId) {
 		Feed feed = feedRepository.findById(feedId)
 				.orElseThrow(() -> new NotFoundException("해당 피드가 존재하지 않습니다"));

--- a/src/main/java/com/example/e2ekernelengine/domain/feed/service/FeedService.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/feed/service/FeedService.java
@@ -74,8 +74,7 @@ public class FeedService {
 	}
 
 	public Page<FeedPageableResponse> findMostClickedFeedList(Pageable pageable) {
-		return feedRepository.findAllByOrderByVisitCountDesc(pageable)
-				.map(FeedPageableResponse::fromEntity);
+		return feedRepository.findAll(pageable).map(FeedPageableResponse::fromEntity);
 	}
 
 	public void increaseDailyVisitCount(Long feedId) {

--- a/src/main/java/com/example/e2ekernelengine/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/user/controller/UserController.java
@@ -27,17 +27,15 @@ public class UserController {
 	@PostMapping("/signup")
 	public String register(
 			@Valid
-					Optional<UserRegisterRequestDto> userRegisterRequestDto
+			Optional<UserRegisterRequestDto> userRegisterRequestDto
 	) {
 		log.info("register request | {}",
 				userRegisterRequestDto.get().getUserName() + " " + userRegisterRequestDto.get().getUserEmail() + " "
 						+ userRegisterRequestDto.get().getUserPassword());
 		UserResponseDto userResponseDto = userService.register(userRegisterRequestDto);
-		// System.out.println(userResponseDto);
 		log.info("request finished");
 		return "redirect:login";
 	}
-
 
 	@PostMapping("/deleteAccount")
 	public String deleteAccount(

--- a/src/main/resources/templates/fragments.html
+++ b/src/main/resources/templates/fragments.html
@@ -36,8 +36,8 @@
                     <li class="nav-item">
                         <a
                                 class="nav-link active"
-                                sec:authorize="isAuthenticated()"
-                                th:href="@{/main}">홈</a>
+                                th:href="@{/main}">홈
+                        </a>
                     </li>
                     <li class="nav-item">
                         <!-- 관리자만 -->

--- a/src/main/resources/templates/fragments.html
+++ b/src/main/resources/templates/fragments.html
@@ -34,7 +34,10 @@
                         </p>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link active" th:href="@{/main}">Home</a>
+                        <a
+                                class="nav-link active"
+                                sec:authorize="isAuthenticated()"
+                                th:href="@{/main}">홈</a>
                     </li>
                     <li class="nav-item">
                         <!-- 관리자만 -->
@@ -43,17 +46,7 @@
                                 sec:authorize="hasAnyRole('ROLE_ADMIN')"
                                 th:href="@{/admin}"
                         >
-                            Admin
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <!-- 로그인한 사람 모두 -->
-                        <a
-                                class="nav-link active"
-                                sec:authorize="isAuthenticated()"
-                                th:href="@{/notice}"
-                        >
-                            Notice
+                            관리자페이지
                         </a>
                     </li>
                     <li class="nav-item">
@@ -63,7 +56,7 @@
                                 sec:authorize="hasAnyRole('ROLE_USER')"
                                 th:href="@{/mypage}"
                         >
-                            Mypage
+                            마이페이지
                         </a>
                     </li>
                     <li class="nav-item">
@@ -73,7 +66,7 @@
                                 sec:authorize="!isAuthenticated()"
                                 th:href="@{/login}"
                         >
-                            Login
+                            로그인
                         </a>
                     </li>
                     <li class="nav-item">
@@ -83,7 +76,7 @@
                                 sec:authorize="!isAuthenticated()"
                                 th:href="@{/signup}"
                         >
-                            SignIn
+                            회원가입
                         </a>
                     </li>
                     <li class="nav-item">
@@ -93,7 +86,7 @@
                                 sec:authorize="isAuthenticated()"
                                 th:href="@{/logout}"
                         >
-                            Logout
+                            로그아웃
                         </a>
                     </li>
                 </ul>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -63,6 +63,16 @@
                            name="query" placeholder="검색어를 입력하세요" type="text">
                 </div>
             </form>
+            <div class="col-sm-2 offset-sm-10">
+                <div class="form-group">
+                    <label for="sort-option">정렬 기준</label>
+                    <select class="form-control" id="sort-option">
+                        <!--<select class="form-control" id="sort-option" onchange="redirectToFeedUrl('${feed.feedUrl}')">-->
+                        <option value="recent">최신순</option>
+                        <option value="clicked">조회순</option>
+                    </select>
+                </div>
+            </div>
         </div>
 
         <div class="container" id="feed-list-block">
@@ -119,11 +129,28 @@
             blogWriterName: ""
         };
 
+        const sortOption = document.getElementById("sort-option");
+        sortOption.addEventListener("change", function (event) {
+            event.preventDefault();
+            handleSortChange();
+        });
+
+        function handleSortChange() {
+            fetchFeedList();
+        }
+
         function fetchFeedList() {
-            fetch(`http://localhost:8080/api/v1/feeds`, {
+            const sortOption = document.getElementById("sort-option").value;
+            let url = `http://localhost:8080/api/v1/feeds`;
+
+            if (sortOption === "clicked") {
+                url = `http://localhost:8080/api/v1/feeds/most-clicked`;
+            }
+
+            fetch(url, {
                 method: 'GET',
                 headers: {
-                    'Content-Type': 'application/json', // JSON 형태의 데이터 전송
+                    'Content-Type': 'application/json',
                 },
             })
                 .then(response => {
@@ -133,19 +160,17 @@
                     return response.json();
                 })
                 .then(data => {
-                    console.log(data);
                     const feedList = data.content;
-                    console.log(feedList);
                     renderFeedList(feedList);
                 })
                 .catch(error => {
-                    // 오류 처리
                     console.error('Error:', error);
                 });
         }
 
         // 피드 목록을 화면에 표시
         function renderFeedList(feedList) {
+            commentListContainer.innerHTML = '';
             feedList.forEach(feed => {
                 const feedDiv = document.createElement("div");
                 feedDiv.innerHTML = `
@@ -176,6 +201,7 @@
     function redirectToFeedUrl(feedUrl) {
         window.location.href = feedUrl;
     }
+
     function increaseDailyAccessCount(feedId) {
         const xhr = new XMLHttpRequest();
         xhr.open(`POST`, `/api/v1/feeds/visit/` + feedId, true);

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -11,12 +11,12 @@
         <h2 class="form-signin-heading">로그인</h2>
         <p>
             <label class="sr-only" for="userEmail">UserEmail</label>
-            <input autofocus class="form-control" id="userEmail" name="userEmail" placeholder="userEmail" required
+            <input autofocus class="form-control" id="userEmail" name="userEmail" placeholder="이메일" required
                    type="text">
         </p>
         <p>
             <label class="sr-only" for="userPassword">Password</label>
-            <input class="form-control" id="userPassword" name="userPassword" placeholder="userPassword" required
+            <input class="form-control" id="userPassword" name="userPassword" placeholder="비밀번호" required
                    type="password">
         </p>
         <div>

--- a/src/main/resources/templates/signup.html
+++ b/src/main/resources/templates/signup.html
@@ -12,21 +12,21 @@
         <!--회원가입에 필요한 요소들 추가-->
         <p>
             <label class="sr-only" for="userEmail">Name</label>
-            <input autofocus class="form-control" id="userName" name="userName" placeholder="userName" required
+            <input autofocus class="form-control" id="userName" name="userName" placeholder="이름" required
                    type="text">
         </p>
         <p>
             <label class="sr-only" for="userEmail">Email</label>
-            <input autofocus class="form-control" id="userEmail" name="userEmail" placeholder="userEmail" required
+            <input autofocus class="form-control" id="userEmail" name="userEmail" placeholder="이메일" required
                    type="text">
         </p>
         <p>
             <label class="sr-only" for="userPassword">Password</label>
-            <input class="form-control" id="userPassword" name="userPassword" placeholder="userPassword" required
+            <input class="form-control" id="userPassword" name="userPassword" placeholder="비밀번호" required
                    type="password">
         </p>
         <p>
-            <input id="admin" name="admin" type="checkbox" value="true">Admin<br>
+            <input id="admin" name="admin" type="checkbox" value="true">어드민<br>
         </p>
         <button class="btn btn-lg btn-primary btn-block" type="submit">회원가입</button>
     </form>


### PR DESCRIPTION
## 💡 Motivation
- 기존: 메인 화면에서 최신 5개의 블로그를 확인할 수 있음
- 수정: 메인 화면에서 최신 5개의 블로그 뿐만 아니라, 가장 많이 조회된 블로그를 보여주는 것도 의미가 있다고 판단


## 🔨 Modified
- 역대 가장 많이 조회된 블로그 api 구현
  - FeedController.java
  - FeedService.java
  - FeedRepository.java
- 화면에 필터링 조건 추가
  - index.html : 필터링 조건에 따라 화면이 바뀌도록 수정
- 메뉴, 네비게이션바 등 영어 -> 한국어
  - fragments.html : 상단 메뉴바 한국어로 수정
  - signup.html: placeholder 한국어로 수정
 
## 🤟🏻 Results
- 최신순으로 정렬된 화면
![image](https://github.com/Kernel360/E2E1-KernelEngine/assets/86637372/71aa0c9a-0f70-4add-8f48-1d0aeea09801)
- 최신순 -> 조회순으로 설정 변경 
![image](https://github.com/Kernel360/E2E1-KernelEngine/assets/86637372/bb7455f5-95d8-43c4-a593-bb3b571eb8dd)
- 조회순으로 정렬된 화면
![image](https://github.com/Kernel360/E2E1-KernelEngine/assets/86637372/845cd128-584f-4621-8fb4-cd8de6c15bae)


## TODO 
- 페이징 처리
- 검색 결과에 대한 정렬도 구현 
- 엔티티를 상위 모듈로 분리하면 일일 가장 많이 조회된 순서에 대한 필터 추가

## Issue
- close # 77


---

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
