### PR TITLE
[Refactor] 게시글 접속 횟수 통계 집계 방식의 변경

### DIFF
--- a/module-batch/src/main/java/com/example/modulebatch/BatchJobScheduler.java
+++ b/module-batch/src/main/java/com/example/modulebatch/BatchJobScheduler.java
@@ -29,9 +29,24 @@ public class BatchJobScheduler {
 	private final MakeFeedStatisticsJobConfig makeFeedStatisticsJobConfig;
 	private final AddDailyRegisteredUserJobConfig addDailyRegisteredUserJobConfig;
 
+	// @Scheduled(initialDelay = 300000, fixedRate = 60000000)
+	@Scheduled(cron = "0 0 2 * * ?")
+	public void runMakeDailyFeedStatistics() {
+		Map<String, JobParameter> confMap = new HashMap<>();
+		confMap.put("time", new JobParameter(System.currentTimeMillis()));
+		JobParameters jobParameters = new JobParameters(confMap);
+
+		try {
+			jobLauncher.run(makeFeedStatisticsJobConfig.makeStatisticsJob(), jobParameters);
+		} catch (JobExecutionAlreadyRunningException | JobParametersInvalidException | JobInstanceAlreadyCompleteException |
+						 JobRestartException e) {
+			log.error(String.valueOf(e));
+		}
+	}
+
 	// @Scheduled(initialDelay = 0, fixedRate = 600000000)
-	@Scheduled(cron = "0 0 4 * * ?")
-	public void runJob() {
+	@Scheduled(cron = "0 0 3 * * ?")
+	public void runAddFeedFromDataLoaderJob() {
 		Map<String, JobParameter> confMap = new HashMap<>();
 		confMap.put("time", new JobParameter(System.currentTimeMillis()));
 		JobParameters jobParameters = new JobParameters(confMap);
@@ -44,22 +59,8 @@ public class BatchJobScheduler {
 		}
 	}
 
-	// @Scheduled(initialDelay = 300000, fixedRate = 60000000)
-	@Scheduled(cron = "0 0 3 * * ?")
-	public void runMakeDailyStatistics() {
-		Map<String, JobParameter> confMap = new HashMap<>();
-		confMap.put("time", new JobParameter(System.currentTimeMillis()));
-		JobParameters jobParameters = new JobParameters(confMap);
-
-		try {
-			jobLauncher.run(makeFeedStatisticsJobConfig.makeStatisticsJob(), jobParameters);
-		} catch (JobExecutionAlreadyRunningException | JobParametersInvalidException | JobInstanceAlreadyCompleteException |
-						 JobRestartException e) {
-			log.error(String.valueOf(e));
-		}
-	}
-	// @Scheduled(initialDelay = 150000, fixedRate = 300000000)
-	@Scheduled(cron = "0 0 3 30 0 ?")
+	// @Scheduled(initialDelay = 600000, fixedRate = 300000000)
+	@Scheduled(cron = "0 0 4 * * ?")
 	public void runMakeUserStatistics() {
 		Map<String, JobParameter> confMap = new HashMap<>();
 		confMap.put("time", new JobParameter(System.currentTimeMillis()));
@@ -72,5 +73,20 @@ public class BatchJobScheduler {
 			log.error(String.valueOf(e));
 		}
 	}
+
+	// TODO:: 오래 지난 조회수 통계 기록 지우기 -> Backlog
+	// @Scheduled(initialDelay = 0, fixedRate = 60000000)
+	// // @Scheduled(cron = "0 0 3 * * ?")
+	// public void runDeleteDailyFeedStatistics() {
+	// 	Map<String, JobParameter> confMap = new HashMap<>();
+	// 	confMap.put("time", new JobParameter(System.currentTimeMillis()));
+	// 	JobParameters jobParameters = new JobParameters(confMap);
+	// 	try {
+	// 		jobLauncher.run(deleteDeprecatedFeedStatisticsJobConfig.deleteDeprecatedFeedStatisticsJob(), jobParameters);
+	// 	} catch (JobExecutionAlreadyRunningException | JobParametersInvalidException | JobInstanceAlreadyCompleteException |
+	// 					 JobRestartException e) {
+	// 		log.error(String.valueOf(e));
+	// 	}
+	// }
 
 }

--- a/module-batch/src/main/java/com/example/modulebatch/ModuleBatchApplication.java
+++ b/module-batch/src/main/java/com/example/modulebatch/ModuleBatchApplication.java
@@ -10,7 +10,6 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @SpringBootApplication(exclude = {SecurityAutoConfiguration.class})
 @EnableBatchProcessing
 @EnableScheduling
-// @SpringBootApplication
 @ComponentScan({"com.example.e2ekernelengine", "com.example.modulebatch"})
 public class ModuleBatchApplication {
 

--- a/module-batch/src/main/java/com/example/modulebatch/user/db/entity/UserRegisterStatistics.java
+++ b/module-batch/src/main/java/com/example/modulebatch/user/db/entity/UserRegisterStatistics.java
@@ -12,19 +12,19 @@ import lombok.Getter;
 
 @Entity
 @Getter
-public class UserStatistics {
+public class UserRegisterStatistics {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long user_stat_id;
 
-	@Column(name = "statistics_at", unique = true)
+	@Column(name = "statistics_at")
 	private LocalDateTime statisticsAt;
 
 	@Column(name = "registered_count")
 	private Integer registeredCount;
 
-	public static UserStatistics create(int registeredCount) {
-		UserStatistics statistics = new UserStatistics();
+	public static UserRegisterStatistics create(int registeredCount) {
+		UserRegisterStatistics statistics = new UserRegisterStatistics();
 		statistics.registeredCount = registeredCount;
 		statistics.statisticsAt = LocalDateTime.now().minusDays(1);
 		return statistics;

--- a/module-batch/src/main/java/com/example/modulebatch/user/db/entity/UserRegisterStatistics.java
+++ b/module-batch/src/main/java/com/example/modulebatch/user/db/entity/UserRegisterStatistics.java
@@ -17,7 +17,7 @@ public class UserRegisterStatistics {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long user_stat_id;
 
-	@Column(name = "statistics_at")
+	@Column(name = "statistics_at", unique = true)
 	private LocalDateTime statisticsAt;
 
 	@Column(name = "registered_count")

--- a/module-batch/src/main/java/com/example/modulebatch/user/db/repository/RegisterUserStatisticsRepository.java
+++ b/module-batch/src/main/java/com/example/modulebatch/user/db/repository/RegisterUserStatisticsRepository.java
@@ -1,0 +1,8 @@
+package com.example.modulebatch.user.db.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.modulebatch.user.db.entity.UserRegisterStatistics;
+
+public interface RegisterUserStatisticsRepository extends JpaRepository<UserRegisterStatistics,Long> {
+}

--- a/module-batch/src/main/java/com/example/modulebatch/user/db/repository/UserRegisterStatisticsRepository.java
+++ b/module-batch/src/main/java/com/example/modulebatch/user/db/repository/UserRegisterStatisticsRepository.java
@@ -4,5 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.example.modulebatch.user.db.entity.UserRegisterStatistics;
 
-public interface RegisterUserStatisticsRepository extends JpaRepository<UserRegisterStatistics,Long> {
+public interface UserRegisterStatisticsRepository extends JpaRepository<UserRegisterStatistics,Long> {
 }

--- a/module-batch/src/main/java/com/example/modulebatch/user/db/repository/UserStatisticsRepository.java
+++ b/module-batch/src/main/java/com/example/modulebatch/user/db/repository/UserStatisticsRepository.java
@@ -1,8 +1,0 @@
-package com.example.modulebatch.user.db.repository;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import com.example.modulebatch.user.db.entity.UserStatistics;
-
-public interface UserStatisticsRepository extends JpaRepository<UserStatistics,Long> {
-}

--- a/module-batch/src/main/java/com/example/modulebatch/user/job/AddDailyRegisteredUserJobConfig.java
+++ b/module-batch/src/main/java/com/example/modulebatch/user/job/AddDailyRegisteredUserJobConfig.java
@@ -16,7 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 public class AddDailyRegisteredUserJobConfig {
 	private final JobBuilderFactory jbf;
 	private final StepBuilderFactory sbf;
-	private final addDailyRegisteredUserTasklet dailyRegisteredUserTasklet;
+	private final AddDailyRegisteredUserTasklet dailyRegisteredUserTasklet;
 
 	@Bean
 	public Job addDailyRegisteredUserJob() {

--- a/module-batch/src/main/java/com/example/modulebatch/user/job/AddDailyRegisteredUserTasklet.java
+++ b/module-batch/src/main/java/com/example/modulebatch/user/job/AddDailyRegisteredUserTasklet.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 import com.example.e2ekernelengine.domain.user.db.entity.User;
 import com.example.e2ekernelengine.domain.user.db.repository.UserRepository;
 import com.example.modulebatch.user.db.entity.UserRegisterStatistics;
-import com.example.modulebatch.user.db.repository.RegisterUserStatisticsRepository;
+import com.example.modulebatch.user.db.repository.UserRegisterStatisticsRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,7 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 @StepScope
 @RequiredArgsConstructor
 public class AddDailyRegisteredUserTasklet implements Tasklet {
-	private final RegisterUserStatisticsRepository registerUserStatisticsRepository;
+	private final UserRegisterStatisticsRepository userRegisterStatisticsRepository;
 	private final UserRepository userRepository;
 
 	@Transactional
@@ -35,7 +35,7 @@ public class AddDailyRegisteredUserTasklet implements Tasklet {
 		Timestamp startDatetime = Timestamp.valueOf(LocalDate.now().atStartOfDay());
 		Timestamp endDatetime = Timestamp.valueOf(LocalDate.now().atTime(23, 59, 59));
 		List<User> registeredLastDay = userRepository.findAllByUserRegisteredAtBetween(startDatetime, endDatetime);
-		registerUserStatisticsRepository.save(UserRegisterStatistics.create(registeredLastDay.size()));
+		userRegisterStatisticsRepository.save(UserRegisterStatistics.create(registeredLastDay.size()));
 		return RepeatStatus.FINISHED;
 	}
 }

--- a/module-batch/src/main/java/com/example/modulebatch/user/job/AddDailyRegisteredUserTasklet.java
+++ b/module-batch/src/main/java/com/example/modulebatch/user/job/AddDailyRegisteredUserTasklet.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 import com.example.e2ekernelengine.domain.user.db.entity.User;
 import com.example.e2ekernelengine.domain.user.db.repository.UserRepository;
 import com.example.modulebatch.user.db.entity.UserRegisterStatistics;
-import com.example.modulebatch.user.db.repository.UserStatisticsRepository;
+import com.example.modulebatch.user.db.repository.RegisterUserStatisticsRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,7 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 @StepScope
 @RequiredArgsConstructor
 public class AddDailyRegisteredUserTasklet implements Tasklet {
-	private final UserStatisticsRepository userStatisticsRepository;
+	private final RegisterUserStatisticsRepository registerUserStatisticsRepository;
 	private final UserRepository userRepository;
 
 	@Transactional
@@ -35,7 +35,7 @@ public class AddDailyRegisteredUserTasklet implements Tasklet {
 		Timestamp startDatetime = Timestamp.valueOf(LocalDate.now().atStartOfDay());
 		Timestamp endDatetime = Timestamp.valueOf(LocalDate.now().atTime(23, 59, 59));
 		List<User> registeredLastDay = userRepository.findAllByUserRegisteredAtBetween(startDatetime, endDatetime);
-		userStatisticsRepository.save(UserRegisterStatistics.create(registeredLastDay.size()));
+		registerUserStatisticsRepository.save(UserRegisterStatistics.create(registeredLastDay.size()));
 		return RepeatStatus.FINISHED;
 	}
 }

--- a/module-batch/src/main/java/com/example/modulebatch/user/job/AddDailyRegisteredUserTasklet.java
+++ b/module-batch/src/main/java/com/example/modulebatch/user/job/AddDailyRegisteredUserTasklet.java
@@ -2,8 +2,6 @@ package com.example.modulebatch.user.job;
 
 import java.sql.Timestamp;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.List;
 
 import javax.transaction.Transactional;
@@ -17,8 +15,8 @@ import org.springframework.stereotype.Component;
 
 import com.example.e2ekernelengine.domain.user.db.entity.User;
 import com.example.e2ekernelengine.domain.user.db.repository.UserRepository;
+import com.example.modulebatch.user.db.entity.UserRegisterStatistics;
 import com.example.modulebatch.user.db.repository.UserStatisticsRepository;
-import com.example.modulebatch.user.db.entity.UserStatistics;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,19 +25,17 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @StepScope
 @RequiredArgsConstructor
-public class addDailyRegisteredUserTasklet implements Tasklet {
+public class AddDailyRegisteredUserTasklet implements Tasklet {
 	private final UserStatisticsRepository userStatisticsRepository;
 	private final UserRepository userRepository;
 
 	@Transactional
 	@Override
 	public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
-		LocalDateTime startDatetime = LocalDateTime.of(LocalDate.now()/*.minusDays(1)*/, LocalTime.of(0, 0, 0));
-		LocalDateTime endDatetime = LocalDateTime.of(LocalDate.now()/*.minusDays(1)*/, LocalTime.of(23, 59, 59));
-
-		List<User> registeredLastDay = userRepository.findAllByUserRegisteredAtBetween(Timestamp.valueOf(startDatetime),
-				Timestamp.valueOf(endDatetime));
-		userStatisticsRepository.save(UserStatistics.create(registeredLastDay.size()));
+		Timestamp startDatetime = Timestamp.valueOf(LocalDate.now().atStartOfDay());
+		Timestamp endDatetime = Timestamp.valueOf(LocalDate.now().atTime(23, 59, 59));
+		List<User> registeredLastDay = userRepository.findAllByUserRegisteredAtBetween(startDatetime, endDatetime);
+		userStatisticsRepository.save(UserRegisterStatistics.create(registeredLastDay.size()));
 		return RepeatStatus.FINISHED;
 	}
 }

--- a/module-batch/src/main/resources/application.yml
+++ b/module-batch/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
       database: mysql
       dialect: org.hibernate.dialect.MySQL8Dialect
     hibernate:
-      ddl-auto: validate
+      ddl-auto: none
 
   datasource:
     url: ${MYSQL_DATABASE_URL}
@@ -17,6 +17,7 @@ spring:
   batch:
     jdbc:
       initialize-schema: always
+
 server:
   port: 8081
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
       database: mysql
       dialect: org.hibernate.dialect.MySQL8Dialect
     hibernate:
-      ddl-auto: validate
+      ddl-auto: none
 
   datasource:
     url: ${MYSQL_DATABASE_URL}


### PR DESCRIPTION
## 💡 Motivation
- #87 


## 🔨 Modified
- 더 이상 매일 Feed의 visitCount를 0으로 초기화하지 않습니다.
- #91 의 경우 백로그로 두겠습니다
- ItemReader를 Cursor방식에서 Paging 방식으로 변경하였습니다.
   - Cursor 형식
     - Database와 커넥션을 맺은 후 데이터를 Streaming 해서 보냅니다.  Cursor를 한 칸씩 옮기면서 데이터를 가져옵니다. 하나의 Connection으로 Batch가 끝날 때까지 사용되기 때문에 Batch가 끝나기 전에 Database와 애플리케이션의 Connection이 먼저 끊어질 수 있습니다. 모든 데이터를 메모리에 저장하기 때문에 메모리 사용량이 많습니다.
   - Paging 형식
     - 페이지 단위로 데이터를 한 번에 조회해오는 방식입니다. 페이지 단위로 커넥션을 맺습니다. 페이징 단위의 결과만 메모리에 저장하기 때문에 상대적으로 메모리 사용량이 적습니다.

 
![image](https://github.com/Kernel360/E2E1-KernelEngine/assets/73059667/7ae2540a-5c58-4dd2-8c50-1619dd7d2063)


**_### Feed 조회수 통계의 경우 피드의 개수만큼 매일 생기기 때문에(조회수 0인 피드는 제외하지만) 읽어와야할 아이템의 갯수가 금방 많아질 것이고 그렇기 때문에 배치 수행시간을 줄이고 타임아웃을 예방하기 위해 페이징 방식으로 전환하였습니다._**


## 🤟🏻 Results
- 통계 테이블을 조회 할 때, 현재까지의 누적조회수와 통계 테이블에 저장된 어제까지의 누적 조회수의 차를 통해 오늘의 조회수를 구할 수 있습니다.
- 주간 조회수를 조회할 때도 마찬가지로, 현재까지의 누적 조회수와 통계테이블에 저장된 지난주까지의 누적 조회추의 차를 통해 주간 조회수를 구할 수 있습니다

## TODO 
- #91
- 관리자 화면에 통계를 연결
- 통계를 연결할 때, 일련의 조회 알고리즘이 필요함

## Issue
- close #87 

---

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
