### PR TITLE
[Feature] 싱글 노드 엘라스틱 서치 서버에 데이터 저장하기 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
-//    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
-    implementation 'org.springframework.data:spring-data-elasticsearch:4.2.2'
+    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+//    implementation 'org.springframework.data:spring-data-elasticsearch:4.2.2'
     implementation 'org.jsoup:jsoup:1.16.1'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 //    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
-//    implementation 'org.springframework.data:spring-data-elasticsearch:4.2.2'
+    implementation 'org.springframework.data:spring-data-elasticsearch:4.2.2'
     implementation 'org.jsoup:jsoup:1.16.1'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/main/java/com/example/e2ekernelengine/crawler/dto/FeedDataDto.java
+++ b/src/main/java/com/example/e2ekernelengine/crawler/dto/FeedDataDto.java
@@ -1,7 +1,9 @@
 package com.example.e2ekernelengine.crawler.dto;
 
+import com.example.e2ekernelengine.domain.blog.db.entity.Blog;
+import com.example.e2ekernelengine.domain.feed.db.entity.Feed;
+import com.example.e2ekernelengine.domain.feed.db.entity.FeedDocument;
 import java.sql.Timestamp;
-
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,9 +14,13 @@ import lombok.Getter;
 public class FeedDataDto {
 
 	private final String link;
+
 	private final String title;
+
 	private final String description;
+
 	private final Timestamp pubDate;
+
 	private final String content;
 
 	@Builder
@@ -25,5 +31,30 @@ public class FeedDataDto {
 		this.pubDate = pubDate;
 		this.description = description;
 		this.content = content;
+	}
+
+	public Feed toEntity(Blog blog) {
+		return Feed.builder()
+						.blog(blog)
+						.feedUrl(link)
+						.feedTitle(title)
+						.feedDescription(description)
+						.feedCreatedAt(pubDate)
+						.feedContent(content)
+						.visitCount(0)
+						.build();
+	}
+
+	public FeedDocument toDocument(Blog blog, Long feedId) {
+		return FeedDocument.builder()
+						.feedId(feedId)
+						.blogTitle(blog.getBlogWriterName())
+						.feedUrl(link)
+						.feedTitle(title)
+						.feedDescription(description)
+						.feedCreatedAt(pubDate)
+						.feedContent(content)
+						.visitCount(0)
+						.build();
 	}
 }

--- a/src/main/java/com/example/e2ekernelengine/crawler/dto/FeedDataDto.java
+++ b/src/main/java/com/example/e2ekernelengine/crawler/dto/FeedDataDto.java
@@ -41,7 +41,7 @@ public class FeedDataDto {
 						.feedDescription(description)
 						.feedCreatedAt(pubDate)
 						.feedContent(content)
-						.visitCount(0)
+						.feedVisitCount(0)
 						.build();
 	}
 
@@ -54,7 +54,7 @@ public class FeedDataDto {
 						.feedDescription(description)
 						.feedCreatedAt(pubDate)
 						.feedContent(content)
-						.visitCount(0)
+						.feedVisitCount(0)
 						.build();
 	}
 }

--- a/src/main/java/com/example/e2ekernelengine/crawler/service/AbstractRssCrawler.java
+++ b/src/main/java/com/example/e2ekernelengine/crawler/service/AbstractRssCrawler.java
@@ -7,11 +7,10 @@ import java.util.Date;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public abstract class AbstractRssCrawler {
+public abstract class AbstractRssCrawler implements IRssCrawler {
 
 	// protected Document connectRSSUrlAndGetXML(String rssFeedUrl) {
 	// 	Document doc = null;

--- a/src/main/java/com/example/e2ekernelengine/crawler/service/ChannelRssCrawler.java
+++ b/src/main/java/com/example/e2ekernelengine/crawler/service/ChannelRssCrawler.java
@@ -1,29 +1,28 @@
 package com.example.e2ekernelengine.crawler.service;
 
+import com.example.e2ekernelengine.crawler.dto.BlogDataDto;
+import com.example.e2ekernelengine.crawler.dto.FeedDataDto;
+import com.example.e2ekernelengine.domain.blog.service.BlogService;
+import com.example.e2ekernelengine.domain.feed.service.FeedService;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.springframework.stereotype.Component;
 
-import com.example.e2ekernelengine.crawler.dto.BlogDataDto;
-import com.example.e2ekernelengine.crawler.dto.FeedDataDto;
-import com.example.e2ekernelengine.domain.blog.service.BlogService;
-import com.example.e2ekernelengine.domain.feed.service.FeedService;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class ChannelRssCrawler extends AbstractRssCrawler implements IRssCrawler {
+public class ChannelRssCrawler extends AbstractRssCrawler {
+
 	private final BlogService blogService;
+
 	private final FeedService feedService;
 
 	/**
@@ -76,7 +75,7 @@ public class ChannelRssCrawler extends AbstractRssCrawler implements IRssCrawler
 			}
 
 			feedDataList.add(FeedDataDto.builder().title(title).link(link).pubDate(pubDate).description(description)
-					.content(content).build());
+							.content(content).build());
 		}
 		return feedDataList;
 	}
@@ -97,13 +96,13 @@ public class ChannelRssCrawler extends AbstractRssCrawler implements IRssCrawler
 		String description = element.selectFirst("description").text();
 		String lastBuildDate = element.selectFirst("lastBuildDate").text();
 		return BlogDataDto.builder()
-				.title(title)
-				.rssLink(rssFeedUrl)
-				.urlLink(urlLink)
-				.description(description)
-				.lastBuildDate(convertStringToTimestamp(lastBuildDate))
-				.lastCrawlDate(new Timestamp(System.currentTimeMillis()))
-				.build();
+						.title(title)
+						.rssLink(rssFeedUrl)
+						.urlLink(urlLink)
+						.description(description)
+						.lastBuildDate(convertStringToTimestamp(lastBuildDate))
+						.lastCrawlDate(new Timestamp(System.currentTimeMillis()))
+						.build();
 	}
 
 }

--- a/src/main/java/com/example/e2ekernelengine/crawler/service/NonChannelRssCrawler.java
+++ b/src/main/java/com/example/e2ekernelengine/crawler/service/NonChannelRssCrawler.java
@@ -1,86 +1,34 @@
 package com.example.e2ekernelengine.crawler.service;
 
+import com.example.e2ekernelengine.crawler.dto.BlogDataDto;
+import com.example.e2ekernelengine.crawler.dto.FeedDataDto;
+import com.example.e2ekernelengine.domain.blog.service.BlogService;
+import com.example.e2ekernelengine.domain.feed.service.FeedService;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.springframework.stereotype.Component;
 
-import com.example.e2ekernelengine.crawler.dto.BlogDataDto;
-import com.example.e2ekernelengine.crawler.dto.FeedDataDto;
-import com.example.e2ekernelengine.domain.blog.service.BlogService;
-import com.example.e2ekernelengine.domain.feed.service.FeedService;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class NonChannelRssCrawler extends AbstractRssCrawler implements IRssCrawler {
-	private final BlogService blogService;
-	private final FeedService feedService;
+public class NonChannelRssCrawler extends AbstractRssCrawler {
 
-	// public static void main(String[] args) {
-	// 	NonChannelRssCrawler r = new NonChannelRssCrawler();
-	// 	r.print();
-	// }
-	//
-	// /**
-	//  * 데이터 콘솔에 출력
-	//  */
-	// public void print() {
-	// 	// List<FeedDataDto> arr = crawlFeedFromBlog("https://hyperconnect.github.io/feed.xml", null);
-	// 	List<FeedDataDto> arr = test();
-	// 	for (int i = 0; i < arr.size(); i++) {
-	// 		System.out.println(arr.get(i).getTitle());
-	// 		System.out.println(arr.get(i).getLink());
-	// 		System.out.println("pubData: " + arr.get(i).getPubDate());
-	// 		System.out.println("description: " + arr.get(i).getDescription());
-	// 		System.out.println("content: " + arr.get(i).getContent());
-	// 		System.out.println();
-	// 	}
-	// }
-	//
-	// private Document connectRSSUrlAndGetXML(String rssFeedUrl) {
-	// 	Document doc = null;
-	// 	try {
-	// 		doc = Jsoup.connect(rssFeedUrl).get();
-	// 	} catch (IOException e) {
-	// 		e.printStackTrace();
-	// 	}
-	// 	return doc;
-	// }
+	private final BlogService blogService;
+
+	private final FeedService feedService;
 
 	private Timestamp convertStringToTimestamp(String dateString) {
 		SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX", Locale.ENGLISH);
 		return getTimestampFromDateStringWithDateFormat(dateString, dateFormat);
-		// dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
-		//
-		// try {
-		// 	Date parsedDate = dateFormat.parse(dateString);
-		// 	return new Timestamp(parsedDate.getTime());
-		// } catch (ParseException e) {
-		// 	log.error(String.valueOf(e));
-		// 	return null;
-		// }
 	}
-
-	// public List<FeedDataDto> test() {
-	// 	// Document doc = connectRSSUrlAndGetXML("https://engineering-skcc.github.io/feed.xml");
-	// 	// BlogDataDto blogDataDto = getBlogData(doc, "https://engineering-skcc.github.io/feed.xml");
-	// 	Document doc = connectRSSUrlAndGetXML("https://hyperconnect.github.io/feed.xml");
-	// 	BlogDataDto blogDataDto = getBlogData(doc, "https://hyperconnect.github.io/feed.xml");
-	// 	System.out.println(blogDataDto.toString());
-	//
-	// 	return getNewFeeds(doc, null);
-	//
-	// }
 
 	private BlogDataDto getBlogData(Document doc, String rssFeedUrl) {
 		Element element = doc.selectFirst("feed");
@@ -89,13 +37,13 @@ public class NonChannelRssCrawler extends AbstractRssCrawler implements IRssCraw
 		String description = element.selectFirst("subtitle").text();
 		String lastBuildDate = element.selectFirst("updated").text();
 		return BlogDataDto.builder()
-				.title(title)
-				.rssLink(rssFeedUrl)
-				.urlLink(urlLink)
-				.description(description)
-				.lastBuildDate(convertStringToTimestamp(lastBuildDate))
-				.lastCrawlDate(new Timestamp(System.currentTimeMillis()))
-				.build();
+						.title(title)
+						.rssLink(rssFeedUrl)
+						.urlLink(urlLink)
+						.description(description)
+						.lastBuildDate(convertStringToTimestamp(lastBuildDate))
+						.lastCrawlDate(new Timestamp(System.currentTimeMillis()))
+						.build();
 	}
 
 	private List<FeedDataDto> getNewFeeds(Document document, Timestamp lastCrawlDate) {
@@ -122,7 +70,7 @@ public class NonChannelRssCrawler extends AbstractRssCrawler implements IRssCraw
 			}
 
 			feedDataList.add(FeedDataDto.builder().title(title).link(link).pubDate(pubDate).description(description)
-					.content(content).build());
+							.content(content).build());
 		}
 		return feedDataList;
 	}

--- a/src/main/java/com/example/e2ekernelengine/domain/feed/db/entity/Feed.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/feed/db/entity/Feed.java
@@ -1,7 +1,7 @@
 package com.example.e2ekernelengine.domain.feed.db.entity;
 
+import com.example.e2ekernelengine.domain.blog.db.entity.Blog;
 import java.sql.Timestamp;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -10,9 +10,6 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
-
-import com.example.e2ekernelengine.domain.blog.db.entity.Blog;
-
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,6 +20,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "feed")
 public class Feed {
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "feed_id", columnDefinition = "BIGINT", nullable = false)
@@ -50,10 +48,10 @@ public class Feed {
 
 	@Column(name = "feed_visit_count")
 	private Integer visitCount;
-
+	
 	@Builder
 	public Feed(Long feedId, Blog blog, String feedUrl, String feedTitle, String feedDescription, String feedContent,
-			Timestamp feedCreatedAt, Integer visitCount) {
+					Timestamp feedCreatedAt, Integer visitCount) {
 		this.feedId = feedId;
 		this.blog = blog;
 		this.feedUrl = feedUrl;

--- a/src/main/java/com/example/e2ekernelengine/domain/feed/db/entity/FeedDocument.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/feed/db/entity/FeedDocument.java
@@ -25,21 +25,21 @@ public class FeedDocument {
 
 	private final String feedDescription;
 
-	private final Integer visitCount;
+	private final Integer feedVisitCount;
 
 	@Id
 	private final Long id;
 
 	@Builder
 	public FeedDocument(String blogTitle, String feedUrl, String feedTitle, String feedContent, Timestamp feedCreatedAt,
-					String feedDescription, Integer visitCount, Long feedId) {
+					String feedDescription, Integer feedVisitCount, Long feedId) {
 		this.blogTitle = blogTitle;
 		this.feedUrl = feedUrl;
 		this.feedTitle = feedTitle;
 		this.feedContent = feedContent;
 		this.feedCreatedAt = feedCreatedAt;
 		this.feedDescription = feedDescription;
-		this.visitCount = visitCount;
+		this.feedVisitCount = feedVisitCount;
 		this.id = feedId;
 	}
 }

--- a/src/main/java/com/example/e2ekernelengine/domain/feed/db/entity/FeedDocument.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/feed/db/entity/FeedDocument.java
@@ -2,6 +2,7 @@ package com.example.e2ekernelengine.domain.feed.db.entity;
 
 import java.sql.Timestamp;
 import javax.persistence.Id;
+import lombok.Builder;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Mapping;
 import org.springframework.data.elasticsearch.annotations.Setting;
@@ -11,23 +12,34 @@ import org.springframework.data.elasticsearch.annotations.Setting;
 @Setting(settingPath = "elasticsearch/feed/feed-setting.json")
 public class FeedDocument {
 
-	@Id
-	private String id;
-
-	private Long feedId;
-
 	//	private Blog blog;
-	private String blogTitle;
+	private final String blogTitle;
 
-	private String feedUrl;
+	private final String feedUrl;
 
-	private String feedTitle;
+	private final String feedTitle;
 
-	private String feedContent;
+	private final String feedContent;
 
-	private Timestamp feedCreatedAt;
+	private final Timestamp feedCreatedAt;
 
-	private String feedDescription;
+	private final String feedDescription;
 
-	private Integer visitCount;
+	private final Integer visitCount;
+
+	@Id
+	private final Long id;
+
+	@Builder
+	public FeedDocument(String blogTitle, String feedUrl, String feedTitle, String feedContent, Timestamp feedCreatedAt,
+					String feedDescription, Integer visitCount, Long feedId) {
+		this.blogTitle = blogTitle;
+		this.feedUrl = feedUrl;
+		this.feedTitle = feedTitle;
+		this.feedContent = feedContent;
+		this.feedCreatedAt = feedCreatedAt;
+		this.feedDescription = feedDescription;
+		this.visitCount = visitCount;
+		this.id = feedId;
+	}
 }

--- a/src/main/java/com/example/e2ekernelengine/domain/feed/db/entity/FeedDocument.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/feed/db/entity/FeedDocument.java
@@ -1,0 +1,33 @@
+package com.example.e2ekernelengine.domain.feed.db.entity;
+
+import java.sql.Timestamp;
+import javax.persistence.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Mapping;
+import org.springframework.data.elasticsearch.annotations.Setting;
+
+@Document(indexName = "feed")
+@Mapping(mappingPath = "elasticsearch/feed/feed-mapping.json")
+@Setting(settingPath = "elasticsearch/feed/feed-setting.json")
+public class FeedDocument {
+
+	@Id
+	private String id;
+
+	private Long feedId;
+
+	//	private Blog blog;
+	private String blogTitle;
+
+	private String feedUrl;
+
+	private String feedTitle;
+
+	private String feedContent;
+
+	private Timestamp feedCreatedAt;
+
+	private String feedDescription;
+
+	private Integer visitCount;
+}

--- a/src/main/java/com/example/e2ekernelengine/domain/search/config/ElasticSearchConfig.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/search/config/ElasticSearchConfig.java
@@ -1,0 +1,21 @@
+package com.example.e2ekernelengine.domain.search.config;
+
+import org.elasticsearch.client.RestHighLevelClient;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.RestClients;
+import org.springframework.data.elasticsearch.config.AbstractElasticsearchConfiguration;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+
+@EnableElasticsearchRepositories
+@Configuration
+public class ElasticSearchConfig extends AbstractElasticsearchConfiguration {
+
+	@Override
+	public RestHighLevelClient elasticsearchClient() {
+		ClientConfiguration clientConfiguration = ClientConfiguration.builder()
+						.connectedTo("localhost:9200")
+						.build();
+		return RestClients.create(clientConfiguration).rest();
+	}
+}

--- a/src/main/java/com/example/e2ekernelengine/domain/search/controller/EsSearchController.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/search/controller/EsSearchController.java
@@ -1,0 +1,27 @@
+package com.example.e2ekernelengine.domain.search.controller;
+
+import com.example.e2ekernelengine.domain.feed.dto.response.FeedPageableResponse;
+import com.example.e2ekernelengine.domain.search.service.EsSearchService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("api/v1/search")
+public class EsSearchController {
+
+	private final EsSearchService esSearchService;
+
+	@GetMapping()
+	public ResponseEntity<List<FeedPageableResponse>> search(@RequestParam(name = "keyword") String keyword) {
+		List<FeedPageableResponse> feedList = esSearchService.search(keyword);
+		return null;
+	}
+
+
+}

--- a/src/main/java/com/example/e2ekernelengine/domain/search/repository/CustomFeedSearchRepository.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/search/repository/CustomFeedSearchRepository.java
@@ -1,0 +1,10 @@
+package com.example.e2ekernelengine.domain.search.repository;
+
+import com.example.e2ekernelengine.domain.feed.db.entity.FeedDocument;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomFeedSearchRepository {
+
+	List<FeedDocument> searchByKeyword(String keyword, Pageable pageable);
+}

--- a/src/main/java/com/example/e2ekernelengine/domain/search/repository/FeedSearchRepository.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/search/repository/FeedSearchRepository.java
@@ -1,0 +1,11 @@
+package com.example.e2ekernelengine.domain.search.repository;
+
+import com.example.e2ekernelengine.domain.feed.db.entity.FeedDocument;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface FeedSearchRepository extends ElasticsearchRepository<FeedDocument, String> {
+
+	List<FeedDocument> findByBlogTitle(String blogTitle, Pageable pageable);
+}

--- a/src/main/java/com/example/e2ekernelengine/domain/search/repository/FeedSearchRepositoryImpl.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/search/repository/FeedSearchRepositoryImpl.java
@@ -1,0 +1,21 @@
+package com.example.e2ekernelengine.domain.search.repository;
+
+import com.example.e2ekernelengine.domain.feed.db.entity.FeedDocument;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class FeedSearchRepositoryImpl implements CustomFeedSearchRepository {
+
+	private final ElasticsearchOperations elasticsearchOperations;
+
+	@Override
+	public List<FeedDocument> searchByKeyword(String keyword, Pageable pageable) {
+		System.out.println("FeedSearchRepositoryImpl.searchByKeyword");
+		return null;
+	}
+}

--- a/src/main/java/com/example/e2ekernelengine/domain/search/service/EsSearchService.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/search/service/EsSearchService.java
@@ -1,0 +1,26 @@
+package com.example.e2ekernelengine.domain.search.service;
+
+import com.example.e2ekernelengine.domain.feed.dto.response.FeedPageableResponse;
+import com.example.e2ekernelengine.domain.search.repository.FeedSearchRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class EsSearchService {
+
+	private final FeedSearchRepository feedSearchRepository;
+
+
+	public List<FeedPageableResponse> search(String keyword) {
+		//		SearchQuery
+		//		feedSearchRepository.searchByKeyword(keyword);
+		feedSearchRepository.findByBlogTitle(keyword, null);
+		return null;
+	}
+}

--- a/src/main/java/com/example/e2ekernelengine/global/config/ElasticSearchConfig.java
+++ b/src/main/java/com/example/e2ekernelengine/global/config/ElasticSearchConfig.java
@@ -1,5 +1,7 @@
 package com.example.e2ekernelengine.domain.search.config;
 
+import com.example.e2ekernelengine.domain.search.repository.FeedSearchRepository;
+import com.example.e2ekernelengine.domain.search.repository.FeedSearchRepositoryImpl;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.elasticsearch.client.ClientConfiguration;
@@ -7,7 +9,7 @@ import org.springframework.data.elasticsearch.client.RestClients;
 import org.springframework.data.elasticsearch.config.AbstractElasticsearchConfiguration;
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
 
-@EnableElasticsearchRepositories
+@EnableElasticsearchRepositories(basePackageClasses = {FeedSearchRepository.class, FeedSearchRepositoryImpl.class})
 @Configuration
 public class ElasticSearchConfig extends AbstractElasticsearchConfiguration {
 

--- a/src/main/java/com/example/e2ekernelengine/global/config/ElasticSearchConfig.java
+++ b/src/main/java/com/example/e2ekernelengine/global/config/ElasticSearchConfig.java
@@ -1,7 +1,5 @@
-package com.example.e2ekernelengine.domain.search.config;
+package com.example.e2ekernelengine.global.config;
 
-import com.example.e2ekernelengine.domain.search.repository.FeedSearchRepository;
-import com.example.e2ekernelengine.domain.search.repository.FeedSearchRepositoryImpl;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.elasticsearch.client.ClientConfiguration;
@@ -9,7 +7,8 @@ import org.springframework.data.elasticsearch.client.RestClients;
 import org.springframework.data.elasticsearch.config.AbstractElasticsearchConfiguration;
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
 
-@EnableElasticsearchRepositories(basePackageClasses = {FeedSearchRepository.class, FeedSearchRepositoryImpl.class})
+//@EnableElasticsearchRepositories(basePackageClasses = {FeedSearchRepository.class, FeedSearchRepositoryImpl.class})
+@EnableElasticsearchRepositories(basePackages = {"com.example.e2ekernelengine.domain.search.repository"})
 @Configuration
 public class ElasticSearchConfig extends AbstractElasticsearchConfiguration {
 

--- a/src/main/java/com/example/e2ekernelengine/global/config/JpaConfig.java
+++ b/src/main/java/com/example/e2ekernelengine/global/config/JpaConfig.java
@@ -1,0 +1,16 @@
+package com.example.e2ekernelengine.global.config;
+
+import com.example.e2ekernelengine.domain.search.repository.FeedSearchRepository;
+import com.example.e2ekernelengine.domain.search.repository.FeedSearchRepositoryImpl;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@EnableJpaRepositories(basePackages = "com.example.e2ekernelengine.domain.**.db.repository",
+				excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
+								classes = {FeedSearchRepository.class, FeedSearchRepositoryImpl.class}))
+@Configuration
+public class JpaConfig {
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,8 @@ logging:
   level:
     com.example: debug
     org.springframework.security: debug
+    org.springframework.data.elasticsearch.client.WIRE: TRACE
+
 
 server:
   port: 8080

--- a/src/main/resources/elasticsearch/docker/Dockerfile
+++ b/src/main/resources/elasticsearch/docker/Dockerfile
@@ -1,0 +1,3 @@
+ARG VERSION
+FROM docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
+RUN elasticsearch-plugin install analysis-nori

--- a/src/main/resources/elasticsearch/docker/docker-compose.yml
+++ b/src/main/resources/elasticsearch/docker/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3.7'
+services:
+  es:
+    build:
+      context: .
+      args:
+        VERSION: 7.10.0
+    container_name: es
+    environment:
+      - node.name=single-node
+      - cluster.name=backtony
+      - discovery.type=single-node
+    ports:
+      - 9200:9200
+      - 9300:9300
+    networks:
+      - es-bridge
+
+  kibana:
+    container_name: kibana
+    image: docker.elastic.co/kibana/kibana:7.10.0
+    environment:
+      SERVER_NAME: kibana
+      ELASTICSEARCH_HOSTS: http://es:9200
+    ports:
+      - 5601:5601
+    # Elasticsearch Start Dependency
+    depends_on:
+      - es
+    networks:
+      - es-bridge
+
+networks:
+  es-bridge:
+    driver: bridge

--- a/src/main/resources/elasticsearch/feed/feed-mapping.json
+++ b/src/main/resources/elasticsearch/feed/feed-mapping.json
@@ -1,0 +1,38 @@
+{
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "feedId": {
+      "type": "long"
+    },
+    "blogTitle": {
+      "type": "string",
+      "analyzer": "my_korean_analyzer"
+    },
+    "feedUrl": {
+      "type": "string"
+    },
+    "feedTitle": {
+      "type": "string",
+      "analyzer": "my_korean_analyzer"
+    },
+    "feedContent": {
+      "type": "string",
+      "analyzer": "my_korean_analyzer"
+    },
+    "feedCreatedAt": {
+      "type": "date",
+      "format": "yyyy-MM-dd HH:mm:ss||epoch_millis"
+    },
+    "feedDescription": {
+      "type": "string",
+      "analyzer": "my_korean_analyzer"
+    },
+    "visitCount": {
+      "type": "integer"
+    }
+  }
+}
+
+

--- a/src/main/resources/elasticsearch/feed/feed-mapping.json
+++ b/src/main/resources/elasticsearch/feed/feed-mapping.json
@@ -1,33 +1,30 @@
 {
   "properties": {
     "id": {
-      "type": "string"
-    },
-    "feedId": {
-      "type": "long"
+      "type": "keyword"
     },
     "blogTitle": {
-      "type": "string",
-      "analyzer": "my_korean_analyzer"
+      "type": "text",
+      "analyzer": "korean"
     },
     "feedUrl": {
-      "type": "string"
+      "type": "keyword"
     },
     "feedTitle": {
-      "type": "string",
-      "analyzer": "my_korean_analyzer"
+      "type": "text",
+      "analyzer": "korean"
     },
     "feedContent": {
-      "type": "string",
-      "analyzer": "my_korean_analyzer"
+      "type": "text",
+      "analyzer": "korean"
     },
     "feedCreatedAt": {
       "type": "date",
       "format": "yyyy-MM-dd HH:mm:ss||epoch_millis"
     },
     "feedDescription": {
-      "type": "string",
-      "analyzer": "my_korean_analyzer"
+      "type": "text",
+      "analyzer": "korean"
     },
     "visitCount": {
       "type": "integer"

--- a/src/main/resources/elasticsearch/feed/feed-mapping.json
+++ b/src/main/resources/elasticsearch/feed/feed-mapping.json
@@ -26,7 +26,7 @@
       "type": "text",
       "analyzer": "korean"
     },
-    "visitCount": {
+    "feedVisitCount": {
       "type": "integer"
     }
   }

--- a/src/main/resources/elasticsearch/feed/feed-mapping.json
+++ b/src/main/resources/elasticsearch/feed/feed-mapping.json
@@ -1,7 +1,7 @@
 {
   "properties": {
     "id": {
-      "type": "keyword"
+      "type": "long"
     },
     "blogTitle": {
       "type": "text",

--- a/src/main/resources/elasticsearch/feed/feed-setting.json
+++ b/src/main/resources/elasticsearch/feed/feed-setting.json
@@ -1,7 +1,7 @@
 {
   "analysis": {
     "analyzer": {
-      "my_korean_analyzer": {
+      "korean": {
         "type": "nori"
       }
     }

--- a/src/main/resources/elasticsearch/feed/feed-setting.json
+++ b/src/main/resources/elasticsearch/feed/feed-setting.json
@@ -1,0 +1,9 @@
+{
+  "analysis": {
+    "analyzer": {
+      "my_korean_analyzer": {
+        "type": "nori"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 💡 Motivation
- #93 

## 🔨 Modified
### crawler
- 은종 멘토님과의 주간 회의때 RssCrawler interface의 implement 위치를 abstract class로 슬쩍 수정했습니다. (계층 상 이상한 부분이 있었음.)
- FeedDataDto 에서 FeedDocument로 변환해주는 메서드를 추가했습니다. 

### es & kibana 도커 띄우기
- 엘라스틱 서치 기반 search API를 구현하기 위해서 es & kibana 서버를 도커 컨테이너로 올리도록 파일을 구성했습니다. 
`src/main/resources/elasticsearch/docker` 위치로 가서 
```
docker-compose up --build
```
명령어를 치시고 다 빌드될 때까지 기다렸다가 `http://localhost:5601`로 들어가시면 우리의 es 서버와 연결된 kibana 사이트를 볼 수 있습니다. 
Dockerfile은 한국어 형태소 분석기 nori 플러그인을 es서버에 설치하기 위해서, docker-compose 파일은 es & kibana 서버를 띄우기 위해서 사용했습니다. 

### FeedDocument
- es 서버에 data를 저장하기 위한 @Document 파일을 작성했습니다. 
- `resources/elasticsearch/feed` 에 존재하는 mapping.json과 setting.json 형식을 따라서 es 서버에 feedDocument 객체를 저장합니다. 
    - `mapping.json` : 필드와 타입, 해당 필드에 붙일 분석기를 명세
    - `setting.json` : 사용할 분석기를 명세

### Reference
https://www.notion.so/elastic-search-408e6fba79d64fbd90c4cad91c8da620?pvs=4
여기에 모아두었습니다..

## 🤟🏻 Results
- es 에 연결해서 크롤링할 때마다 es 서버에 데이터 같이 저장함.

## TODO 
- es 에 들어간 데이터 눈으로 볼 수 있는 방법 찾기...ㅋㅋ
   - 이렇게 kibana의 dev tool에 쿼리를 날리면 
      <img width="638" alt="image" src="https://github.com/Kernel360/E2E1-KernelEngine/assets/68376744/4f27d335-922d-4d8a-b648-fd0edd3a4c5f">
       ```
         GET feed/_search
         {
              "query" : {
                  "match_all" : {}
              }
         }
       ```
       
       다음의 사진과 같은 결과가 나오는 걸 통해서 데이터가 들어갔음을 알 수 있고 
       <img width="552" alt="image" src="https://github.com/Kernel360/E2E1-KernelEngine/assets/68376744/19464de7-2ebb-44de-aad6-024b05fa93c4">
        
       es를 대상으로한 간단한 쿼리 요청을 kibana 의 devtool에서 할 수 있습니다. 

- 진짜진짜 search API 만들기 
- 성능 비교하기 
- es서버를 똑똑하게 사용하는 법 고민해보기 

## Issue
- close #93 

---

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
