### PR TITLE
[Refactor] 로그인 시, 기존에 머물렀던 페이지로 이동

### DIFF
--- a/src/main/java/com/example/e2ekernelengine/domain/user/token/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/user/token/filter/JwtAuthenticationFilter.java
@@ -59,8 +59,13 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 
 		String refreshToken = tokenService.createAndStoreRefreshToken(user);
 		addAuthenticationCookie(request, response, refreshToken, false);
-
-		response.sendRedirect("/");
+		
+		String preLoginUrl = request.getParameter("preLoginUrl");
+		if (preLoginUrl != null && !preLoginUrl.isBlank()) {
+			response.sendRedirect(preLoginUrl);
+		} else {
+			response.sendRedirect("/");
+		}
 	}
 
 	private void addAuthenticationCookie(HttpServletRequest request, HttpServletResponse response, String token,

--- a/src/main/java/com/example/e2ekernelengine/global/config/SpringSecurityConfig.java
+++ b/src/main/java/com/example/e2ekernelengine/global/config/SpringSecurityConfig.java
@@ -77,7 +77,6 @@ public class SpringSecurityConfig extends WebSecurityConfigurerAdapter {
 				.loginPage("/login")
 				.usernameParameter("userEmail")
 				.passwordParameter("userPassword")
-				.defaultSuccessUrl("/", true)
 				.failureUrl("/login")
 				.permitAll();
 		http.logout()

--- a/src/main/resources/templates/fragments.html
+++ b/src/main/resources/templates/fragments.html
@@ -63,6 +63,7 @@
                         <!-- 로그인 안한 사람만 -->
                         <a
                                 class="nav-link active"
+                                id="loginLink"
                                 sec:authorize="!isAuthenticated()"
                                 th:href="@{/login}"
                         >
@@ -93,6 +94,16 @@
             </div>
         </div>
     </nav>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            var loginLink = document.getElementById('loginLink');
+            if (loginLink) {
+                loginLink.addEventListener('click', function () {
+                    localStorage.setItem('preLoginUrl', window.location.href);
+                });
+            }
+        });
+    </script>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -9,6 +9,9 @@
 <div class="container">
     <form class="form-signin" method="post" th:action="@{/login}">
         <h2 class="form-signin-heading">로그인</h2>
+
+        <input id="preLoginUrl" name="preLoginUrl" type="hidden" value="">
+
         <p>
             <label class="sr-only" for="userEmail">UserEmail</label>
             <input autofocus class="form-control" id="userEmail" name="userEmail" placeholder="이메일" required
@@ -25,6 +28,11 @@
         </div>
         <button class="btn btn-lg btn-primary btn-block" type="submit">로그인</button>
     </form>
+    <script>
+        document.addEventListener("DOMContentLoaded", function () {
+            document.getElementById('preLoginUrl').value = localStorage.getItem('preLoginUrl') || '/';
+        });
+    </script>
 </div>
 </body>
 </html>


### PR DESCRIPTION
## 💡 Motivation
- 로그인한 후, 기존에 머물렀던 페이지가 아닌 메인페이지로 이동하게되어 사용자 편의성이 미흡함



## 🔨 Modified
- 상단 메뉴바에서 로그인 메뉴를 선택하면 현재 머물러있는 페이지의 url 정보(preLoginUrl)를 localstorage에 저장
- 로그인폼을 제출할 때 서버로 preLoginUrl 정보를 함께 전송
- 서버에서 preLoginUrl을 이용해 로그인하기 전 페이지로 redirect

## 🤟🏻 Results
- 로그인한 후, 머물렀던 페이지로 바로 이동

## TODO 


## Issue
- close # 100


---

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
