### PR TITLE
[Feature] : 엘라스틱 서치로 검색 기능 구현

### DIFF
--- a/src/main/java/com/example/e2ekernelengine/crawler/dto/FeedDataDto.java
+++ b/src/main/java/com/example/e2ekernelengine/crawler/dto/FeedDataDto.java
@@ -1,9 +1,11 @@
 package com.example.e2ekernelengine.crawler.dto;
 
+import java.sql.Timestamp;
+
 import com.example.e2ekernelengine.domain.blog.db.entity.Blog;
 import com.example.e2ekernelengine.domain.feed.db.entity.Feed;
 import com.example.e2ekernelengine.domain.feed.db.entity.FeedDocument;
-import java.sql.Timestamp;
+
 import lombok.Builder;
 import lombok.Getter;
 
@@ -35,26 +37,26 @@ public class FeedDataDto {
 
 	public Feed toEntity(Blog blog) {
 		return Feed.builder()
-						.blog(blog)
-						.feedUrl(link)
-						.feedTitle(title)
-						.feedDescription(description)
-						.feedCreatedAt(pubDate)
-						.feedContent(content)
-						.feedVisitCount(0)
-						.build();
+				.blog(blog)
+				.feedUrl(link)
+				.feedTitle(title)
+				.feedDescription(description)
+				.feedCreatedAt(pubDate)
+				.feedContent(content)
+				.feedVisitCount(0)
+				.build();
 	}
 
 	public FeedDocument toDocument(Blog blog, Long feedId) {
 		return FeedDocument.builder()
-						.feedId(feedId)
-						.blogTitle(blog.getBlogWriterName())
-						.feedUrl(link)
-						.feedTitle(title)
-						.feedDescription(description)
-						.feedCreatedAt(pubDate)
-						.feedContent(content)
-						.feedVisitCount(0)
-						.build();
+				.id(feedId)
+				.blogTitle(blog.getBlogWriterName())
+				.feedUrl(link)
+				.feedTitle(title)
+				.feedDescription(description)
+				.feedCreatedAt(pubDate.getTime())
+				.feedContent(content)
+				.feedVisitCount(0)
+				.build();
 	}
 }

--- a/src/main/java/com/example/e2ekernelengine/domain/blog/db/repository/BlogJpaRepository.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/blog/db/repository/BlogJpaRepository.java
@@ -1,20 +1,14 @@
 package com.example.e2ekernelengine.domain.blog.db.repository;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.example.e2ekernelengine.domain.blog.db.entity.Blog;
 
 @Repository
 public interface BlogJpaRepository extends JpaRepository<Blog, Long> {
-
-	@Query("SELECT b.blogId FROM Blog b WHERE b.blogWriterName = :blogWriterName")
-	List<Long> findBlogIdsByBlogWriterName(@Param("blogWriterName") String blogWriterName);
 
 	Optional<Blog> findByBlogRssUrl(String rssLink);
 }

--- a/src/main/java/com/example/e2ekernelengine/domain/feed/db/entity/FeedDocument.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/feed/db/entity/FeedDocument.java
@@ -1,15 +1,18 @@
 package com.example.e2ekernelengine.domain.feed.db.entity;
 
-import java.sql.Timestamp;
 import javax.persistence.Id;
-import lombok.Builder;
+
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Mapping;
 import org.springframework.data.elasticsearch.annotations.Setting;
 
+import lombok.Builder;
+import lombok.Getter;
+
 @Document(indexName = "feed")
 @Mapping(mappingPath = "elasticsearch/feed/feed-mapping.json")
 @Setting(settingPath = "elasticsearch/feed/feed-setting.json")
+@Getter
 public class FeedDocument {
 
 	//	private Blog blog;
@@ -21,7 +24,7 @@ public class FeedDocument {
 
 	private final String feedContent;
 
-	private final Timestamp feedCreatedAt;
+	private final Long feedCreatedAt;
 
 	private final String feedDescription;
 
@@ -31,8 +34,8 @@ public class FeedDocument {
 	private final Long id;
 
 	@Builder
-	public FeedDocument(String blogTitle, String feedUrl, String feedTitle, String feedContent, Timestamp feedCreatedAt,
-					String feedDescription, Integer feedVisitCount, Long feedId) {
+	public FeedDocument(String blogTitle, String feedUrl, String feedTitle, String feedContent, Long feedCreatedAt,
+			String feedDescription, Integer feedVisitCount, Long id) {
 		this.blogTitle = blogTitle;
 		this.feedUrl = feedUrl;
 		this.feedTitle = feedTitle;
@@ -40,6 +43,6 @@ public class FeedDocument {
 		this.feedCreatedAt = feedCreatedAt;
 		this.feedDescription = feedDescription;
 		this.feedVisitCount = feedVisitCount;
-		this.id = feedId;
+		this.id = id;
 	}
 }

--- a/src/main/java/com/example/e2ekernelengine/domain/feed/db/repository/FeedRepository.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/feed/db/repository/FeedRepository.java
@@ -12,7 +12,10 @@ import com.example.e2ekernelengine.domain.feed.db.entity.Feed;
 @Repository
 public interface FeedRepository extends JpaRepository<Feed, Long> {
 
-	@Query("SELECT f FROM Feed f WHERE LOWER(f.feedTitle) LIKE %:keyword% OR LOWER(f.feedContent) LIKE %:keyword%")
+	@Query("select f from Feed f where lower(f.feedTitle) like lower(concat('%', :keyword, '%')) "
+			+ "or lower(f.feedContent) like lower(concat('%', :keyword, '%')) "
+			+ "or lower(f.feedDescription) like lower(concat('%', :keyword, '%'))"
+			+ "or lower(f.blog.blogWriterName) like lower(concat('%', :keyword, '%')) ")
 	Page<Feed> searchFeedsByKeyword(@Param("keyword") String keyword, Pageable request);
 
 	Page<Feed> findAll(Pageable request);

--- a/src/main/java/com/example/e2ekernelengine/domain/feed/service/FeedService.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/feed/service/FeedService.java
@@ -13,7 +13,7 @@ import com.example.e2ekernelengine.domain.blog.db.repository.BlogJpaRepository;
 import com.example.e2ekernelengine.domain.feed.db.entity.Feed;
 import com.example.e2ekernelengine.domain.feed.db.repository.FeedRepository;
 import com.example.e2ekernelengine.domain.feed.dto.response.FeedPageableResponse;
-import com.example.e2ekernelengine.domain.search.repository.FeedSearchRepository;
+import com.example.e2ekernelengine.domain.search.repository.EsFeedSearchRepository;
 import com.example.e2ekernelengine.global.exception.NotFoundException;
 
 import lombok.RequiredArgsConstructor;
@@ -26,7 +26,7 @@ public class FeedService {
 
 	private final BlogJpaRepository blogJpaRepository;
 
-	private final FeedSearchRepository feedSearchRepository;
+	private final EsFeedSearchRepository esFeedSearchRepository;
 
 	// TODO: @Autowired 대신 생성자 주입을 사용하자. 인줄 알ㄹ았는데 쓴 이유가 있으신지 물어보기
 	// TODO: 답변: 협의되기 전에 작성한 코드입니다. 리팩토링 주 때 통일시키는 작업 진행하도록 하겠습니다.
@@ -78,7 +78,7 @@ public class FeedService {
 			// 					.build();
 
 			feedRepository.save(feed);
-			feedSearchRepository.save(feedData.toDocument(blog, feed.getFeedId()));
+			esFeedSearchRepository.save(feedData.toDocument(blog, feed.getFeedId()));
 		}
 	}
 

--- a/src/main/java/com/example/e2ekernelengine/domain/feed/service/FeedService.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/feed/service/FeedService.java
@@ -1,5 +1,12 @@
 package com.example.e2ekernelengine.domain.feed.service;
 
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.example.e2ekernelengine.crawler.dto.FeedDataDto;
 import com.example.e2ekernelengine.domain.blog.db.entity.Blog;
 import com.example.e2ekernelengine.domain.blog.db.repository.BlogJpaRepository;
@@ -8,13 +15,8 @@ import com.example.e2ekernelengine.domain.feed.db.repository.FeedRepository;
 import com.example.e2ekernelengine.domain.feed.dto.response.FeedPageableResponse;
 import com.example.e2ekernelengine.domain.search.repository.FeedSearchRepository;
 import com.example.e2ekernelengine.global.exception.NotFoundException;
-import java.util.List;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -27,6 +29,7 @@ public class FeedService {
 	private final FeedSearchRepository feedSearchRepository;
 
 	// TODO: @Autowired 대신 생성자 주입을 사용하자. 인줄 알ㄹ았는데 쓴 이유가 있으신지 물어보기
+	// TODO: 답변: 협의되기 전에 작성한 코드입니다. 리팩토링 주 때 통일시키는 작업 진행하도록 하겠습니다.
 	//	@Autowired
 	//	public FeedService(FeedRepository feedRepository, BlogJpaRepository blogJpaRepository) {
 	//		this.feedRepository = feedRepository;
@@ -39,10 +42,10 @@ public class FeedService {
 		Page<Feed> page = feedRepository.searchFeedsByKeyword(keyword, pageable);
 		// List<Long> searchBlogsByBlogWriterName = blogJpaRepository.findBlogIdsByBlogWriterName(keyword);
 
-// 		return searchFeedsByKeyword.stream()
-// 						.map(FeedPageableResponse::fromEntity)
-// 						.collect(Collectors.toList());
-    
+		// 		return searchFeedsByKeyword.stream()
+		// 						.map(FeedPageableResponse::fromEntity)
+		// 						.collect(Collectors.toList());
+
 		return page.map(FeedPageableResponse::fromEntity);
 
 		// for (Long blogId : searchBlogsByBlogWriterName) {
@@ -64,15 +67,15 @@ public class FeedService {
 		Blog blog = blogJpaRepository.findById(blogId).orElseThrow(() -> new NotFoundException("해당 블로그가 존재하지 않습니다."));
 		for (FeedDataDto feedData : feedDataList) {
 			Feed feed = feedData.toEntity(blog);
-// 			Feed feed = Feed.builder()
-// 					.blog(blog)
-// 					.feedUrl(feedData.getLink())
-// 					.feedTitle(feedData.getTitle())
-// 					.feedDescription(feedData.getDescription())
-// 					.feedCreatedAt(feedData.getPubDate())
-// 					.feedContent(feedData.getContent())
-// 					.feedVisitCount(0)
-// 					.build();
+			// 			Feed feed = Feed.builder()
+			// 					.blog(blog)
+			// 					.feedUrl(feedData.getLink())
+			// 					.feedTitle(feedData.getTitle())
+			// 					.feedDescription(feedData.getDescription())
+			// 					.feedCreatedAt(feedData.getPubDate())
+			// 					.feedContent(feedData.getContent())
+			// 					.feedVisitCount(0)
+			// 					.build();
 
 			feedRepository.save(feed);
 			feedSearchRepository.save(feedData.toDocument(blog, feed.getFeedId()));
@@ -89,7 +92,7 @@ public class FeedService {
 
 	public void increaseDailyVisitCount(Long feedId) {
 		Feed feed = feedRepository.findById(feedId)
-						.orElseThrow(() -> new NotFoundException("해당 피드가 존재하지 않습니다"));
+				.orElseThrow(() -> new NotFoundException("해당 피드가 존재하지 않습니다"));
 		feed.increaseVisitCount();
 		feedRepository.save(feed);
 	}

--- a/src/main/java/com/example/e2ekernelengine/domain/feed/service/FeedService.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/feed/service/FeedService.java
@@ -30,35 +30,11 @@ public class FeedService {
 
 	// TODO: @Autowired 대신 생성자 주입을 사용하자. 인줄 알ㄹ았는데 쓴 이유가 있으신지 물어보기
 	// TODO: 답변: 협의되기 전에 작성한 코드입니다. 리팩토링 주 때 통일시키는 작업 진행하도록 하겠습니다.
-	//	@Autowired
-	//	public FeedService(FeedRepository feedRepository, BlogJpaRepository blogJpaRepository) {
-	//		this.feedRepository = feedRepository;
-	//		this.blogJpaRepository = blogJpaRepository;
-	//	}
 
 	@Transactional
 	public Page<FeedPageableResponse> searchFeedsByKeyword(String keyword, Pageable pageable) {
-
 		Page<Feed> page = feedRepository.searchFeedsByKeyword(keyword, pageable);
-		// List<Long> searchBlogsByBlogWriterName = blogJpaRepository.findBlogIdsByBlogWriterName(keyword);
-
-		// 		return searchFeedsByKeyword.stream()
-		// 						.map(FeedPageableResponse::fromEntity)
-		// 						.collect(Collectors.toList());
-
 		return page.map(FeedPageableResponse::fromEntity);
-
-		// for (Long blogId : searchBlogsByBlogWriterName) {
-		// 	List<Feed> blogFeeds = feedRepository.searchFeedsByBlog_BlogId(blogId);
-		// 	List<FeedSearchResponseDto> blogFeedResponses = blogFeeds.stream()
-		// 			.map(feed -> FeedSearchResponseDto
-		// 					.create(feed.getFeedId(),
-		// 							feed.getFeedUrl(),
-		// 							feed.getFeedTitle(),
-		// 							feed.getFeedContent()))
-		// 			.collect(Collectors.toList());
-		// 	feedResponseList.addAll(blogFeedResponses);
-		// }
 	}
 
 	@Transactional

--- a/src/main/java/com/example/e2ekernelengine/domain/search/controller/EsSearchController.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/search/controller/EsSearchController.java
@@ -19,12 +19,7 @@ import lombok.RequiredArgsConstructor;
 public class EsSearchController {
 
 	private final EsSearchService esSearchService;
-
-	/*@GetMapping()
-	public ResponseEntity<List<FeedPageableResponse>> search(@RequestParam(name = "keyword") String keyword) {
-		List<FeedPageableResponse> feedList = esSearchService.search(keyword);
-		return null;
-	}*/
+	
 	@GetMapping()
 	public ResponseEntity<Page<EsFeedPageableResponse>> search(
 			@RequestParam(value = "q") String keyword,

--- a/src/main/java/com/example/e2ekernelengine/domain/search/controller/EsSearchController.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/search/controller/EsSearchController.java
@@ -1,14 +1,17 @@
 package com.example.e2ekernelengine.domain.search.controller;
 
-import com.example.e2ekernelengine.domain.feed.dto.response.FeedPageableResponse;
-import com.example.e2ekernelengine.domain.search.service.EsSearchService;
-import java.util.List;
-import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.example.e2ekernelengine.domain.search.dto.response.EsFeedPageableResponse;
+import com.example.e2ekernelengine.domain.search.service.EsSearchService;
+
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @RestController
@@ -17,11 +20,20 @@ public class EsSearchController {
 
 	private final EsSearchService esSearchService;
 
-	@GetMapping()
+	/*@GetMapping()
 	public ResponseEntity<List<FeedPageableResponse>> search(@RequestParam(name = "keyword") String keyword) {
 		List<FeedPageableResponse> feedList = esSearchService.search(keyword);
 		return null;
+	}*/
+	@GetMapping()
+	public ResponseEntity<Page<EsFeedPageableResponse>> search(
+			@RequestParam(value = "q") String keyword,
+			Pageable pageable) {
+		Page<EsFeedPageableResponse> feedPage = esSearchService.searchFeedsByKeyword(keyword, pageable);
+		if (feedPage.isEmpty()) {
+			return ResponseEntity.notFound().build();
+		}
+		return ResponseEntity.ok(feedPage);
 	}
-
 
 }

--- a/src/main/java/com/example/e2ekernelengine/domain/search/dto/response/EsFeedPageableResponse.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/search/dto/response/EsFeedPageableResponse.java
@@ -1,0 +1,28 @@
+package com.example.e2ekernelengine.domain.search.dto.response;
+
+import com.example.e2ekernelengine.domain.feed.db.entity.FeedDocument;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class EsFeedPageableResponse {
+	private final Long feedId;
+	private final String feedUrl;
+	private final String feedTitle;
+	private final String feedDescription;
+	private final String feedCreatedAt;
+	private final String blogWriterName;
+
+	public static EsFeedPageableResponse fromDocument(FeedDocument feedDocument) {
+		return EsFeedPageableResponse.builder()
+				.feedId(feedDocument.getId())
+				.feedUrl(feedDocument.getFeedUrl())
+				.feedTitle(feedDocument.getFeedTitle())
+				.feedDescription(feedDocument.getFeedDescription())
+				.feedCreatedAt(feedDocument.getFeedCreatedAt().toString())
+				.blogWriterName(feedDocument.getBlogTitle())
+				.build();
+	}
+}

--- a/src/main/java/com/example/e2ekernelengine/domain/search/repository/EsFeedSearchRepository.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/search/repository/EsFeedSearchRepository.java
@@ -9,8 +9,6 @@ import com.example.e2ekernelengine.domain.feed.db.entity.FeedDocument;
 
 public interface EsFeedSearchRepository extends ElasticsearchRepository<FeedDocument, String> {
 
-	// List<FeedDocument> findByBlogTitle(String blogTitle, Pageable pageable);
-
 	@Query("{\"bool\": {\"should\": [" +
 			"{\"match\": {\"feedTitle\": \"?0\"}}," +
 			"{\"match\": {\"feedContent\": \"?0\"}}," +

--- a/src/main/java/com/example/e2ekernelengine/domain/search/repository/EsFeedSearchRepository.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/search/repository/EsFeedSearchRepository.java
@@ -14,6 +14,7 @@ public interface EsFeedSearchRepository extends ElasticsearchRepository<FeedDocu
 	@Query("{\"bool\": {\"should\": [" +
 			"{\"match\": {\"feedTitle\": \"?0\"}}," +
 			"{\"match\": {\"feedContent\": \"?0\"}}," +
+			"{\"match\": {\"feedDescription\": \"?0\"}}," +
 			"{\"match\": {\"blogTitle\": \"?0\"}}" +
 			"]}}")
 	Page<FeedDocument> searchFeedsByKeyword(String keyword, Pageable pageable);

--- a/src/main/java/com/example/e2ekernelengine/domain/search/repository/EsFeedSearchRepository.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/search/repository/EsFeedSearchRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.elasticsearch.repository.ElasticsearchRepository
 
 import com.example.e2ekernelengine.domain.feed.db.entity.FeedDocument;
 
-public interface FeedSearchRepository extends ElasticsearchRepository<FeedDocument, String> {
+public interface EsFeedSearchRepository extends ElasticsearchRepository<FeedDocument, String> {
 
 	// List<FeedDocument> findByBlogTitle(String blogTitle, Pageable pageable);
 

--- a/src/main/java/com/example/e2ekernelengine/domain/search/repository/FeedSearchRepository.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/search/repository/FeedSearchRepository.java
@@ -1,11 +1,20 @@
 package com.example.e2ekernelengine.domain.search.repository;
 
-import com.example.e2ekernelengine.domain.feed.db.entity.FeedDocument;
-import java.util.List;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.annotations.Query;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+import com.example.e2ekernelengine.domain.feed.db.entity.FeedDocument;
 
 public interface FeedSearchRepository extends ElasticsearchRepository<FeedDocument, String> {
 
-	List<FeedDocument> findByBlogTitle(String blogTitle, Pageable pageable);
+	// List<FeedDocument> findByBlogTitle(String blogTitle, Pageable pageable);
+
+	@Query("{\"bool\": {\"should\": [" +
+			"{\"match\": {\"feedTitle\": \"?0\"}}," +
+			"{\"match\": {\"feedContent\": \"?0\"}}," +
+			"{\"match\": {\"blogTitle\": \"?0\"}}" +
+			"]}}")
+	Page<FeedDocument> searchFeedsByKeyword(String keyword, Pageable pageable);
 }

--- a/src/main/java/com/example/e2ekernelengine/domain/search/service/EsSearchService.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/search/service/EsSearchService.java
@@ -7,7 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.example.e2ekernelengine.domain.feed.db.entity.FeedDocument;
 import com.example.e2ekernelengine.domain.search.dto.response.EsFeedPageableResponse;
-import com.example.e2ekernelengine.domain.search.repository.FeedSearchRepository;
+import com.example.e2ekernelengine.domain.search.repository.EsFeedSearchRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,7 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 public class EsSearchService {
 
-	private final FeedSearchRepository feedSearchRepository;
+	private final EsFeedSearchRepository esFeedSearchRepository;
 
 
 	/*public List<FeedPageableResponse> search(String keyword) {
@@ -30,7 +30,7 @@ public class EsSearchService {
 
 	public Page<EsFeedPageableResponse> searchFeedsByKeyword(String keyword, Pageable pageable) {
 
-		Page<FeedDocument> page = feedSearchRepository.searchFeedsByKeyword(
+		Page<FeedDocument> page = esFeedSearchRepository.searchFeedsByKeyword(
 				keyword, pageable);
 		return page.map(EsFeedPageableResponse::fromDocument);
 

--- a/src/main/java/com/example/e2ekernelengine/domain/search/service/EsSearchService.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/search/service/EsSearchService.java
@@ -20,14 +20,6 @@ public class EsSearchService {
 
 	private final EsFeedSearchRepository esFeedSearchRepository;
 
-
-	/*public List<FeedPageableResponse> search(String keyword) {
-		//		SearchQuery
-		//		feedSearchRepository.searchByKeyword(keyword);
-		feedSearchRepository.findByBlogTitle(keyword, null);
-		return null;
-	}*/
-
 	public Page<EsFeedPageableResponse> searchFeedsByKeyword(String keyword, Pageable pageable) {
 
 		Page<FeedDocument> page = esFeedSearchRepository.searchFeedsByKeyword(

--- a/src/main/java/com/example/e2ekernelengine/domain/search/service/EsSearchService.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/search/service/EsSearchService.java
@@ -1,12 +1,16 @@
 package com.example.e2ekernelengine.domain.search.service;
 
-import com.example.e2ekernelengine.domain.feed.dto.response.FeedPageableResponse;
-import com.example.e2ekernelengine.domain.search.repository.FeedSearchRepository;
-import java.util.List;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.example.e2ekernelengine.domain.feed.db.entity.FeedDocument;
+import com.example.e2ekernelengine.domain.search.dto.response.EsFeedPageableResponse;
+import com.example.e2ekernelengine.domain.search.repository.FeedSearchRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -17,10 +21,18 @@ public class EsSearchService {
 	private final FeedSearchRepository feedSearchRepository;
 
 
-	public List<FeedPageableResponse> search(String keyword) {
+	/*public List<FeedPageableResponse> search(String keyword) {
 		//		SearchQuery
 		//		feedSearchRepository.searchByKeyword(keyword);
 		feedSearchRepository.findByBlogTitle(keyword, null);
 		return null;
+	}*/
+
+	public Page<EsFeedPageableResponse> searchFeedsByKeyword(String keyword, Pageable pageable) {
+
+		Page<FeedDocument> page = feedSearchRepository.searchFeedsByKeyword(
+				keyword, pageable);
+		return page.map(EsFeedPageableResponse::fromDocument);
+
 	}
 }

--- a/src/main/java/com/example/e2ekernelengine/global/config/JpaConfig.java
+++ b/src/main/java/com/example/e2ekernelengine/global/config/JpaConfig.java
@@ -1,15 +1,16 @@
 package com.example.e2ekernelengine.global.config;
 
-import com.example.e2ekernelengine.domain.search.repository.FeedSearchRepository;
-import com.example.e2ekernelengine.domain.search.repository.FeedSearchRepositoryImpl;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
+import com.example.e2ekernelengine.domain.search.repository.EsFeedSearchRepository;
+import com.example.e2ekernelengine.domain.search.repository.FeedSearchRepositoryImpl;
+
 @EnableJpaRepositories(basePackages = "com.example.e2ekernelengine.domain.**.db.repository",
-				excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
-								classes = {FeedSearchRepository.class, FeedSearchRepositoryImpl.class}))
+		excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
+				classes = {EsFeedSearchRepository.class, FeedSearchRepositoryImpl.class}))
 @Configuration
 public class JpaConfig {
 


### PR DESCRIPTION
## 💡 Motivation
- mysql 기반 검색과 엘라스틱서치 기반 검색 비교



## 🔨 Modified
- 엘라스틱 검색 API
  - EsSearchController
  - EsFeedSearchRepository
    ```
    {
      "bool": {
        "should": [
          {"match": {"feedTitle": "?0"}},
          {"match": {"feedContent": "?0"}},
          {"match": {"feedDescription": "?0"}},
          {"match": {"blogTitle": "?0"}}
        ]
      }
    }
    ```
    - `bool`: bool 쿼리는 bool( true / false ) 로직을 사용하는 쿼리
    - `should`: bool should 절에 지정된 모든 쿼리 중 하나라도 일치하는 document를 조회
    - `match`: match 쿼리는 기본 필드 검색 쿼리로써, 텍스트/숫자/날짜를 허용
    - `?0` : 검색어로 대체될 자리 표시자
    - 참고한 블로그: 
      - https://victorydntmd.tistory.com/314
      - https://velog.io/@backtony/Spring-Data-Elasticsearch-%EA%B0%9C%EB%85%90-%EB%B0%8F-%EB%AC%B8%EC%84%9C-%EB%B2%88%EC%97%AD-e0utk986#elasticsearch
  - EsSearchService
  - EsFeedPageableResponse
-  Refactor: 이름 변경
  - FeedSearchRepository -> EsFeedSearchRepository 
- Fix: 일반 검색 API에서 검색하는 범위 확장
  - 기존: feedTitle, feedContent
  - 개선: feedTitle, feeedContent, **feedDescription, blogWriterName**


## 🤟🏻 Results
- 엘라스틱 기반 검색 API 기능 구현
![image](https://github.com/Kernel360/E2E1-KernelEngine/assets/86637372/a72b96b6-71eb-4451-8791-2d2bb84b1959)
![image](https://github.com/Kernel360/E2E1-KernelEngine/assets/86637372/98b22eda-b31f-4435-b36a-1d742816eaf1)

## TODO 
- API별 성능 측정
- 일반 검색 API, 엘라스틱 검색 API 성능 개선

## Issue
- close # 106



---

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
