### PR TITLE
[Feature] 데일리 Top 10 피드 리스트를 관리자 페이지에 구현

### DIFF
--- a/src/main/java/com/example/e2ekernelengine/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/admin/controller/AdminController.java
@@ -1,13 +1,15 @@
 package com.example.e2ekernelengine.domain.admin.controller;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
+import com.example.e2ekernelengine.domain.admin.dto.response.DailyTop10FeedListResponse;
 import com.example.e2ekernelengine.domain.admin.dto.response.UserCountResponse;
 import com.example.e2ekernelengine.domain.admin.service.AdminService;
-
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -15,6 +17,12 @@ import lombok.RequiredArgsConstructor;
 public class AdminController {
 
 	private final AdminService adminService;
+
+	@GetMapping("feed/top10/daily")
+	public DailyTop10FeedListResponse getDailyTop10FeedList(
+					@RequestParam(name = "date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+		return adminService.getDailyTop10FeedList(date);
+	}
 
 	@GetMapping("user-count/jpa")
 	public UserCountResponse getTotalUserCountByJpa() {

--- a/src/main/java/com/example/e2ekernelengine/domain/admin/dto/MostVisitedFeedDto.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/admin/dto/MostVisitedFeedDto.java
@@ -1,0 +1,55 @@
+package com.example.e2ekernelengine.domain.admin.dto;
+
+import com.example.e2ekernelengine.domain.feed.db.entity.Feed;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MostVisitedFeedDto {
+
+	private final String feedTitle;
+
+	private final String feedUrl;
+
+	private final String blogTitle;
+
+	private final String blogWriterName;
+
+	private final String publishedDate;
+
+	private final Integer feedVisitCount;
+
+	@Builder
+	public MostVisitedFeedDto(String feedTitle, String feedUrl, String blogTitle, String blogWriterName,
+					String publishedDate, Integer feedVisitCount) {
+		this.feedTitle = feedTitle;
+		this.feedUrl = feedUrl;
+		this.blogTitle = blogTitle;
+		this.blogWriterName = blogWriterName;
+		this.publishedDate = publishedDate;
+		this.feedVisitCount = feedVisitCount;
+	}
+
+	public static MostVisitedFeedDto from(Feed feed) {
+		return MostVisitedFeedDto.builder()
+						.feedTitle(feed.getFeedTitle())
+						.feedUrl(feed.getFeedUrl())
+						.blogTitle(feed.getBlog().getBlogDescription())
+						.blogWriterName(feed.getBlog().getBlogWriterName())
+						.publishedDate(feed.getFeedCreatedAt().toString())
+						.feedVisitCount(feed.getFeedVisitCount())
+						.build();
+	}
+
+	public MostVisitedFeedDto of(String feedTitle, String feedUrl, String blogTitle, String blogWriterName,
+					String publishedDate, Integer feedVisitCount) {
+		return MostVisitedFeedDto.builder()
+						.feedTitle(feedTitle)
+						.feedUrl(feedUrl)
+						.blogTitle(blogTitle)
+						.blogWriterName(blogWriterName)
+						.publishedDate(publishedDate)
+						.feedVisitCount(feedVisitCount)
+						.build();
+	}
+}

--- a/src/main/java/com/example/e2ekernelengine/domain/admin/dto/response/DailyTop10FeedListResponse.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/admin/dto/response/DailyTop10FeedListResponse.java
@@ -1,0 +1,19 @@
+package com.example.e2ekernelengine.domain.admin.dto.response;
+
+import com.example.e2ekernelengine.domain.admin.dto.MostVisitedFeedDto;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class DailyTop10FeedListResponse {
+
+	List<MostVisitedFeedDto> dailyTop10FeedList;
+
+	public DailyTop10FeedListResponse(List<MostVisitedFeedDto> dailyTop10FeedList) {
+		this.dailyTop10FeedList = dailyTop10FeedList;
+	}
+
+	public static DailyTop10FeedListResponse from(List<MostVisitedFeedDto> dailyTop10FeedList) {
+		return new DailyTop10FeedListResponse(dailyTop10FeedList);
+	}
+}

--- a/src/main/java/com/example/e2ekernelengine/domain/statistics/db/entity/FeedStatistics.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/statistics/db/entity/FeedStatistics.java
@@ -1,14 +1,11 @@
-package com.example.modulebatch.feed.db.entity;
+package com.example.e2ekernelengine.domain.statistics.db.entity;
 
+import com.example.e2ekernelengine.domain.feed.db.entity.Feed;
 import java.time.LocalDateTime;
-
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-
-import com.example.e2ekernelengine.domain.feed.db.entity.Feed;
-
 import lombok.Getter;
 import lombok.ToString;
 
@@ -16,17 +13,21 @@ import lombok.ToString;
 @Getter
 @ToString
 public class FeedStatistics {
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long feedStatId;
+
+
 	private Long feedId;
+
 	private LocalDateTime statisticsAt;
 
 	private Integer visitCount;
 
 	public static FeedStatistics create(final Feed feed) {
 		FeedStatistics statistics = new FeedStatistics();
-		statistics.visitCount = feed.getVisitCount();
+		statistics.visitCount = feed.getFeedVisitCount();
 		statistics.feedId = feed.getFeedId();
 		statistics.statisticsAt = LocalDateTime.now().minusDays(1);
 		return statistics;

--- a/src/main/java/com/example/e2ekernelengine/domain/statistics/db/repository/DailyFeedStatisticsRepository.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/statistics/db/repository/DailyFeedStatisticsRepository.java
@@ -1,0 +1,18 @@
+package com.example.e2ekernelengine.domain.statistics.db.repository;
+
+import com.example.e2ekernelengine.domain.statistics.db.entity.FeedStatistics;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface DailyFeedStatisticsRepository extends JpaRepository<FeedStatistics, Long> {
+
+	// TODO: 진짜..querydsl로 바꿔야할듯
+	@Query(value = "SELECT * FROM feed_statistics fs WHERE fs.statistics_at >= :startDate AND fs.statistics_at < :endDate ORDER BY fs.visit_count DESC LIMIT 10", nativeQuery = true)
+	List<FeedStatistics> findTop10ByStatisticsAtOrderByVisitCountDesc(
+					@Param("startDate") LocalDateTime startDate,
+					@Param("endDate") LocalDateTime endDate
+	);
+}

--- a/src/main/resources/templates/manage/adminPage.html
+++ b/src/main/resources/templates/manage/adminPage.html
@@ -371,26 +371,6 @@ to get the desired effect
                                         <td>
                                             <img alt="Product 1" class="img-circle img-size-32 mr-2"
                                                  src="/dist/img/default-150x150.png">
-                                            Some Product
-                                        </td>
-                                        <td>$13 USD</td>
-                                        <td>
-                                            <small class="text-success mr-1">
-                                                <i class="fas fa-arrow-up"></i>
-                                                12%
-                                            </small>
-                                            12,000 Sold
-                                        </td>
-                                        <td>
-                                            <a class="text-muted" href="#">
-                                                <i class="fas fa-search"></i>
-                                            </a>
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td>
-                                            <img alt="Product 1" class="img-circle img-size-32 mr-2"
-                                                 src="/dist/img/default-150x150.png">
                                             Another Product
                                         </td>
                                         <td>$29 USD</td>
@@ -407,47 +387,7 @@ to get the desired effect
                                             </a>
                                         </td>
                                     </tr>
-                                    <tr>
-                                        <td>
-                                            <img alt="Product 1" class="img-circle img-size-32 mr-2"
-                                                 src="/dist/img/default-150x150.png">
-                                            Amazing Product
-                                        </td>
-                                        <td>$1,230 USD</td>
-                                        <td>
-                                            <small class="text-danger mr-1">
-                                                <i class="fas fa-arrow-down"></i>
-                                                3%
-                                            </small>
-                                            198 Sold
-                                        </td>
-                                        <td>
-                                            <a class="text-muted" href="#">
-                                                <i class="fas fa-search"></i>
-                                            </a>
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td>
-                                            <img alt="Product 1" class="img-circle img-size-32 mr-2"
-                                                 src="/dist/img/default-150x150.png">
-                                            Perfect Item
-                                            <span class="badge bg-danger">NEW</span>
-                                        </td>
-                                        <td>$199 USD</td>
-                                        <td>
-                                            <small class="text-success mr-1">
-                                                <i class="fas fa-arrow-up"></i>
-                                                63%
-                                            </small>
-                                            87 Sold
-                                        </td>
-                                        <td>
-                                            <a class="text-muted" href="#">
-                                                <i class="fas fa-search"></i>
-                                            </a>
-                                        </td>
-                                    </tr>
+
                                     </tbody>
                                 </table>
                             </div>
@@ -456,7 +396,7 @@ to get the desired effect
 
                         <div class="card">
                             <div class="card-header border-0">
-                                <h3 class="card-title">hot한 게시물</h3>
+                                <h3 class="card-title">오늘의 핫한 피드</h3>
                                 <div class="card-tools">
                                     <a class="btn btn-tool btn-sm" href="#">
                                         <i class="fas fa-download"></i>
@@ -470,73 +410,16 @@ to get the desired effect
                                 <table class="table table-striped table-valign-middle">
                                     <thead>
                                     <tr>
-                                        <th>Product</th>
-                                        <th>Price</th>
-                                        <th>Sales</th>
-                                        <th>More</th>
+                                        <th>피드 제목</th>
+                                        <th>블로그 제목</th>
+                                        <th>블로그 작성자 이름</th>
+                                        <th>피드 발행일</th>
+                                        <th>피드 조회수</th>
                                     </tr>
                                     </thead>
-                                    <tbody>
-                                    <tr>
-                                        <td>
-                                            <img alt="Product 1" class="img-circle img-size-32 mr-2"
-                                                 src="/dist/img/default-150x150.png">
-                                            Some Product
-                                        </td>
-                                        <td>$13 USD</td>
-                                        <td>
-                                            <small class="text-success mr-1">
-                                                <i class="fas fa-arrow-up"></i>
-                                                12%
-                                            </small>
-                                            12,000 Sold
-                                        </td>
-                                        <td>
-                                            <a class="text-muted" href="#">
-                                                <i class="fas fa-search"></i>
-                                            </a>
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td>
-                                            <img alt="Product 1" class="img-circle img-size-32 mr-2"
-                                                 src="/dist/img/default-150x150.png">
-                                            Another Product
-                                        </td>
-                                        <td>$29 USD</td>
-                                        <td>
-                                            <small class="text-warning mr-1">
-                                                <i class="fas fa-arrow-down"></i>
-                                                0.5%
-                                            </small>
-                                            123,234 Sold
-                                        </td>
-                                        <td>
-                                            <a class="text-muted" href="#">
-                                                <i class="fas fa-search"></i>
-                                            </a>
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td>
-                                            <img alt="Product 1" class="img-circle img-size-32 mr-2"
-                                                 src="/dist/img/default-150x150.png">
-                                            Amazing Product
-                                        </td>
-                                        <td>$1,230 USD</td>
-                                        <td>
-                                            <small class="text-danger mr-1">
-                                                <i class="fas fa-arrow-down"></i>
-                                                3%
-                                            </small>
-                                            198 Sold
-                                        </td>
-                                        <td>
-                                            <a class="text-muted" href="#">
-                                                <i class="fas fa-search"></i>
-                                            </a>
-                                        </td>
-                                    </tr>
+
+                                    <tbody id="daily-top-10-feed">
+
                                     <tr>
                                         <td>
                                             <img alt="Product 1" class="img-circle img-size-32 mr-2"
@@ -607,7 +490,7 @@ to get the desired effect
                                 <tr>
                                     <th>
                                         <div class="form-floating mb-3">
-                                            <label for="blogTitle">blog title</label>
+                                            <label for="blogTitle">블로그 제목</label>
                                             <input class="form-control" id="blogTitle"
                                                    placeholder="네이버 기술 블로그"
                                                    required type="text">
@@ -811,6 +694,47 @@ to get the desired effect
             });
         });
     });
+</script>
+
+<script>
+<!--    DailyTop10Feed-->
+
+    function initializeDailyTop10Feed() {
+
+        var currentDate = new Date();
+        var formattedDate = currentDate.toISOString().slice(0, 10);
+
+        $.ajax({
+            url: `http://localhost:8080/api/v1/admin/feed/top10/daily?date=` + formattedDate,
+            method: "GET",
+            success: function (data) {
+                console.log(data);
+                putDaily10TopOnPage(data.dailyTop10FeedList);
+            },
+            error: function (error) {
+                console.error("데이터를 가져오는데 실패했습니다.", error);
+            }
+        });
+    }
+
+    function putDaily10TopOnPage(feedList) {
+
+        var tbody = $("#daily-top-10-feed");
+
+        $.each(feedList, function (index, feed) {
+            var newRow = $("<tr>");
+            newRow.append("<td><a href='" + feed.feedUrl + "'>" + feed.feedTitle + "</a></td>");
+            newRow.append("<td>" + feed.blogTitle + "</td>");
+            newRow.append("<td>" + feed.blogWriterName + "</td>");
+            newRow.append("<td>" + feed.publishedDate + "</td>");
+            newRow.append("<td>" + feed.feedVisitCount + "</td>");
+            tbody.append(newRow);
+        });
+        return feedList;
+    }
+
+    initializeDailyTop10Feed();
+
 </script>
 
 <!-- OPTIONAL SCRIPTS -->

--- a/src/main/resources/templates/manage/adminPage.html
+++ b/src/main/resources/templates/manage/adminPage.html
@@ -419,28 +419,6 @@ to get the desired effect
                                     </thead>
 
                                     <tbody id="daily-top-10-feed">
-
-                                    <tr>
-                                        <td>
-                                            <img alt="Product 1" class="img-circle img-size-32 mr-2"
-                                                 src="/dist/img/default-150x150.png">
-                                            Perfect Item
-                                            <span class="badge bg-danger">NEW</span>
-                                        </td>
-                                        <td>$199 USD</td>
-                                        <td>
-                                            <small class="text-success mr-1">
-                                                <i class="fas fa-arrow-up"></i>
-                                                63%
-                                            </small>
-                                            87 Sold
-                                        </td>
-                                        <td>
-                                            <a class="text-muted" href="#">
-                                                <i class="fas fa-search"></i>
-                                            </a>
-                                        </td>
-                                    </tr>
                                     </tbody>
                                 </table>
                             </div>


### PR DESCRIPTION
## 💡 Motivation
- #84 

## 🔨 Modified
### FeedStatistics & DailyFeedStatisticsRepository
- 현재 계층이 있는 모듈 관계라서 통계 데이터 조회를 위해서 필요한 entity와 repository를 root module로 가져왔습니다. 
### 나머지
- endpoint query에 날린 날짜에 통계낸 데이터에 대해서 조회수가 높은 순서대로 위에서 10개를 짤라서 보여줍니다.

## 🤟🏻 Results
- 관리자 페이지에서 오늘 핫한 피드 10개를 조회수 순서대로 정렬해서 보여줌.

## TODO 
- 이걸 사실 원하는 날짜를 선택해서 조회하게 할 수 있게 backend api는 구현했으나 프론트에서 구현하지 않았습니다. 추후에 해도 될 것 같아요
- 쿼리가 너무 비효율적 + native인데 querydsl로 바꾸고 싶어요

## Issue
- close #84 

---

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
