### PR TITLE
[Feature] 기본 검색 필터를 elastic search 기반 연관성 높은 결과 순으로 설정 + 필터링 정확도순 추가

### DIFF
--- a/src/main/java/com/example/e2ekernelengine/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/feed/controller/FeedController.java
@@ -47,7 +47,10 @@ public class FeedController {
 		return "searchResults";
 	}
 
-	private void prepareModel(Model model, Page<FeedPageableResponse> feedPage, String keyword,
+	private void prepareModel(
+			Model model,
+			Page<FeedPageableResponse> feedPage,
+			String keyword,
 			String selectedSortOption) {
 		int currentPage = feedPage.getNumber();
 		int totalPages = feedPage.getTotalPages();

--- a/src/main/java/com/example/e2ekernelengine/domain/search/controller/EsSearchController.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/search/controller/EsSearchController.java
@@ -2,7 +2,9 @@ package com.example.e2ekernelengine.domain.search.controller;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.ResponseEntity;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -15,12 +17,12 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("api/v1/search")
+@RequestMapping("api/v1/feeds")
 public class EsSearchController {
 
 	private final EsSearchService esSearchService;
 	
-	@GetMapping()
+	/*@GetMapping("/search/accurate")
 	public ResponseEntity<Page<EsFeedPageableResponse>> search(
 			@RequestParam(value = "q") String keyword,
 			Pageable pageable) {
@@ -29,6 +31,32 @@ public class EsSearchController {
 			return ResponseEntity.notFound().build();
 		}
 		return ResponseEntity.ok(feedPage);
+	}*/
+
+	@GetMapping("/search/accurate")
+	public String searchFeedBy(
+			@RequestParam(value = "q") String keyword,
+			@PageableDefault(size = 5, sort = "feedAccurate", direction = Sort.Direction.DESC) Pageable pageable,
+			Model model) {
+		Page<EsFeedPageableResponse> feedPage = esSearchService.searchFeedsByKeyword(keyword, pageable);
+		prepareModel(model, feedPage, keyword, "accurate");
+		return "searchResults";
+	}
+
+	private void prepareModel(Model model,
+			Page<EsFeedPageableResponse> feedPage,
+			String keyword,
+			String selectedSortOption) {
+		int currentPage = feedPage.getNumber();
+		int totalPages = feedPage.getTotalPages();
+		int startPage = Math.max(0, currentPage - 2);
+		int endPage = Math.min(currentPage + 2, totalPages - 1);
+
+		model.addAttribute("feedPage", feedPage);
+		model.addAttribute("query", keyword);
+		model.addAttribute("startPage", startPage);
+		model.addAttribute("endPage", endPage);
+		model.addAttribute("selectedSortOption", selectedSortOption);
 	}
 
 }

--- a/src/main/java/com/example/e2ekernelengine/domain/search/controller/EsSearchController.java
+++ b/src/main/java/com/example/e2ekernelengine/domain/search/controller/EsSearchController.java
@@ -2,13 +2,12 @@ package com.example.e2ekernelengine.domain.search.controller;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
 
 import com.example.e2ekernelengine.domain.search.dto.response.EsFeedPageableResponse;
 import com.example.e2ekernelengine.domain.search.service.EsSearchService;
@@ -16,30 +15,20 @@ import com.example.e2ekernelengine.domain.search.service.EsSearchService;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-@RestController
+@Controller
 @RequestMapping("api/v1/feeds")
 public class EsSearchController {
 
 	private final EsSearchService esSearchService;
-	
-	/*@GetMapping("/search/accurate")
-	public ResponseEntity<Page<EsFeedPageableResponse>> search(
-			@RequestParam(value = "q") String keyword,
-			Pageable pageable) {
-		Page<EsFeedPageableResponse> feedPage = esSearchService.searchFeedsByKeyword(keyword, pageable);
-		if (feedPage.isEmpty()) {
-			return ResponseEntity.notFound().build();
-		}
-		return ResponseEntity.ok(feedPage);
-	}*/
 
 	@GetMapping("/search/accurate")
 	public String searchFeedBy(
 			@RequestParam(value = "q") String keyword,
-			@PageableDefault(size = 5, sort = "feedAccurate", direction = Sort.Direction.DESC) Pageable pageable,
+			@PageableDefault(size = 5) Pageable pageable,
 			Model model) {
 		Page<EsFeedPageableResponse> feedPage = esSearchService.searchFeedsByKeyword(keyword, pageable);
 		prepareModel(model, feedPage, keyword, "accurate");
+
 		return "searchResults";
 	}
 

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -110,7 +110,7 @@
 
             const query = searchInput.value;
             if (query) {
-                window.location.href = "/api/v1/feeds/search/recent?q=" + encodeURIComponent(query);
+                window.location.href = "/api/v1/feeds/search/accurate?q=" + encodeURIComponent(query);
             }
         });
     });

--- a/src/main/resources/templates/searchResults.html
+++ b/src/main/resources/templates/searchResults.html
@@ -72,7 +72,7 @@
 </div>
 
 <div id="search-results">
-    <h1>검색 결과</h1>
+    <!--<h1>검색 결과</h1>-->
     <div class="container" id="feed-list-block">
         <form id="feed-list">
             <div th:each="feed : ${feedPage}">
@@ -99,9 +99,11 @@
             </div>
             <div class="container">
                 <ul class="pagination justify-content-center">
-                    <li class="page-item" th:if="${feedPage.hasPrevious()}">
+                    <li class="page-item" th:if="${!feedPage.isFirst()}">
                         <a class="page-link"
-                           th:href="@{/api/v1/feeds/search/{sort}(q=${query}, page=${feedPage.number - 1}, sort=${selectedSortOption})}">이전</a>
+                           th:href="@{/api/v1/feeds/search/{sort}(q=${query}, page=0, sort=${selectedSortOption})}">
+                            처음
+                        </a>
                     </li>
                     <li class="page-item" th:classappend="${pageNum == feedPage.number} ? 'active'"
                         th:each="pageNum : ${#numbers.sequence(startPage, endPage)}">
@@ -109,9 +111,11 @@
                            th:href="@{/api/v1/feeds/search/{sort}(q=${query}, page=${pageNum}, sort=${selectedSortOption})}"
                            th:text="${pageNum + 1}"></a>
                     </li>
-                    <li class="page-item" th:if="${feedPage.hasNext()}">
+                    <li class="page-item" th:if="${!feedPage.isLast()}">
                         <a class="page-link"
-                           th:href="@{/api/v1/feeds/search/{sort}(q=${query}, page=${feedPage.number + 1}, sort=${selectedSortOption})}">다음</a>
+                           th:href="@{/api/v1/feeds/search/{sort}(q=${query}, page=${endPage - 1}, sort=${selectedSortOption})}">
+                            마지막
+                        </a>
                     </li>
                 </ul>
             </div>

--- a/src/main/resources/templates/searchResults.html
+++ b/src/main/resources/templates/searchResults.html
@@ -63,6 +63,7 @@
         <div class="form-group">
             <label for="sort-option">정렬 기준</label>
             <select class="form-control" id="sort-option">
+                <option th:selected="${selectedSortOption == 'accurate'}" value="clicked">정확도순</option>
                 <option th:selected="${selectedSortOption == 'recent'}" value="recent">최신순</option>
                 <option th:selected="${selectedSortOption == 'clicked'}" value="clicked">조회순</option>
             </select>
@@ -134,10 +135,12 @@
             const queryParams = new URLSearchParams(window.location.search);
             const query = queryParams.get('q');
             console.log(query);
-            let url = '/api/v1/feeds/search/recent?q=' + encodeURIComponent(query);
+            let url = '/api/v1/feeds/search/accurate?q=' + encodeURIComponent(query);
 
             if (selectedOption === 'clicked') {
                 url = '/api/v1/feeds/search/clicked?q=' + encodeURIComponent(query);
+            } else if (selectedOption === 'recent') {
+                url = '/api/v1/feeds/search/recent?q=' + encodeURIComponent(query);
             }
 
             window.location.href = url;
@@ -180,7 +183,8 @@
             const selectedSortOption = sortOptionSelect.value;
 
             if (query) {
-                let url;
+                let url = "/api/v1/feeds/search/accurate?q=" + encodeURIComponent(query);
+
                 if (selectedSortOption === 'clicked') {
                     url = "/api/v1/feeds/search/clicked?q=" + encodeURIComponent(query);
                 } else {

--- a/src/main/resources/templates/searchResults.html
+++ b/src/main/resources/templates/searchResults.html
@@ -80,16 +80,19 @@
                     /* feed 객체 정보를 콘솔에 출력 */
                     console.log([[${feed.feedUrl}]]);
                 </script>
-                <div class="row justify-content-md-center"
+                <div class="card-body"
                      onclick="redirectToFeedUrl('${feed.feedUrl}'); increaseDailyAccessCount('${feed.feedId}');">
-                    <div class="col-md-auto">
-                        <p id="feedId" style="display:none;" th:text="${feed.feedId}"></p>
-                        <p id="feedUrl" style="display:none;" th:text="${feed.feedUrl}"></p>
-
-                        <p id="feedTitle" th:text="'제목: ' + ${feed.feedTitle}"></p>
-                        <p id="blogWriterName" th:text="'작성자: ' + ${feed.blogWriterName}"></p>
-                        <p id="feedDescription" th:text="'내용: ' + ${feed.feedDescription}"></p>
-                        <p id="feedCreatedAt" th:text="'생성일: ' + ${feed.feedCreatedAt}"></p>
+                    <div class="post">
+                        <div class="user-block">
+                            <p id="feedId" style="display:none;" th:text="${feed.feedId}"></p>
+                            <p id="feedUrl" style="display:none;" th:text="${feed.feedUrl}"></p>
+                            <p id="feedTitle" style="font-size: 20px; font-weight: bold;"
+                               th:text="'제목: ' + ${feed.feedTitle}"></p>
+                            <p id="blogWriterName" th:text="'작성자: ' + ${feed.blogWriterName}"></p>
+                            <p id="feedCreatedAt" th:text="'생성일: ' + ${feed.feedCreatedAt}"></p>
+                            <p id="feedDescription" th:text="'내용: ' + ${feed.feedDescription}"></p>
+                        </div>
+                        <br>
                     </div>
                 </div>
                 <!--                </form>-->


### PR DESCRIPTION
## 💡 Motivation
- 엘라스틱 서치의 기본 정렬 방식은 관련성 점수(_score)를 기반으로 함
- **내부 원리**: 엘라스틱서치에서 쿼리를 수행할 때 각 문서에 대해 관련성 점수를 계산하고, 이 점수가 가장 높은 문서부터 낮은 문서 순으로 결과를 반환
- **쿼리와 문서 간 관련성을 결정하는 요소**:
  - **용어 빈도**: 
    - 쿼리에 있는 단어가 **문서 내**에서 얼마나 자주 등장하는지
    -  **자주 등장**할수록 높은 점수
  - **역문서 빈도**: 
    - 한 단어가 문서 **집합 전체**에서 얼마나 자주 등장하는지
    - **희귀**할수록 높은 점수
  - **필드 길이**: 
    - 데이터를 문자 형식으로 표시하는 데 필요한 최대 문자 수
    - **짧은 필드**일수록 높은 점수

- 이 모든 것을 종합해서 우리는 `정확도순`으로 검색 조건 표기
- 정확도순을 디폴트로 설정

![image](https://github.com/Kernel360/E2E1-KernelEngine/assets/86637372/643211d9-0f65-4589-9f0c-e915284ab0a3)



## 🔨 Modified
- 메인화면에서 검색하면 최신순 검색 -> 정확도순 검색
- 필터 조건 정확도순 추가

## 🤟🏻 Results
- 메인화면에서 검색
![image](https://github.com/Kernel360/E2E1-KernelEngine/assets/86637372/27d7cabe-e37a-439e-80bf-08cb2f214eb8)
- 정확도순으로 검색된 결과
![image](https://github.com/Kernel360/E2E1-KernelEngine/assets/86637372/dfde60d3-761e-4eb2-a200-c53a05617981)
- 필터링 조건 선택 가능
  - 정확도순
  - 최신순
  - 조회순
![image](https://github.com/Kernel360/E2E1-KernelEngine/assets/86637372/f625b160-4a20-4725-8800-f4be4ff4952b)
--------
- 페이징도 처음 또는 마지막 페이지로 바로 이동할 수 있도록 수정
![image](https://github.com/Kernel360/E2E1-KernelEngine/assets/86637372/36447905-dea2-413a-b3b5-707e208f0e4a)



## TODO 
- 

## Issue
- close #127


---

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
